### PR TITLE
feat/12/로그인페이지

### DIFF
--- a/src/app/(with-header)/login/_components/LoginForm.tsx
+++ b/src/app/(with-header)/login/_components/LoginForm.tsx
@@ -1,0 +1,99 @@
+"use client";
+import { useForm } from "react-hook-form";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useLogin } from "@/lib/hooks/useAuth";
+import { LoginRequest, loginRequestSchema } from "@/lib/types/auth";
+import Link from "next/link";
+import Image from "next/image";
+import logo from "@/assets/logo/logo-lg.svg";
+import eye from "@/assets/icons/eye.svg";
+import eyeVisible from "@/assets/icons/eye-visible.svg";
+import Input from "@/components/Input";
+import Button from "@/components/Button";
+import SocialLogin from "@/components/SocialLogin";
+
+export default function LoginForm() {
+  const { mutateAsync: login } = useLogin();
+  const router = useRouter();
+  const [isShowPassword, setIsShowPassword] = useState(false);
+  const {
+    register,
+    handleSubmit,
+    trigger,
+    setError,
+    formState: { errors, isSubmitting, isValid },
+  } = useForm<LoginRequest>({
+    resolver: zodResolver(loginRequestSchema),
+    mode: "onChange",
+  });
+
+  const onSubmit = async (data: LoginRequest) => {
+    try {
+      await login(data);
+      router.push("/epigrams");
+    } catch (error) {
+      console.error("로그인 실패", error);
+      setError("email", {
+        type: "manual",
+        message: "이메일 혹은 비밀번호를 확인해 주세요.",
+      });
+    }
+  };
+
+  return (
+    <div className="relative mx-auto max-w-[640px] min-w-[312px] mt-[120px] md:mt-[150px] px-4 md:px-0">
+      <Link href="/">
+        <Image
+          src={logo}
+          alt="로고"
+          width={172}
+          height={48}
+          className="mx-auto mb-[50px]"
+        />
+      </Link>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <Input
+          type="email"
+          placeholder="이메일을 입력하세요"
+          {...register("email")}
+          error={errors.email?.message}
+        />
+        <div className="relative">
+          <Input
+            type={isShowPassword ? "text" : "password"}
+            placeholder="비밀번호를 입력하세요"
+            {...register("password", {
+              onBlur: () => trigger("password"),
+            })}
+            error={errors.password?.message}
+          />
+          <Image
+            src={isShowPassword ? eyeVisible : eye}
+            width={24}
+            height={24}
+            alt="비밀번호 눈 아이콘"
+            onClick={() => setIsShowPassword((prev) => !prev)}
+            className="cursor-pointer absolute top-[28px] lg:top-[38px] right-4"
+          />
+        </div>
+        <Button
+          type="submit"
+          size="xl"
+          className="w-full mt-[20px]"
+          disabled={!isValid || isSubmitting}
+        >
+          로그인
+        </Button>
+      </form>
+      <p className="mt-12 text-center font-medium text-md lg:text-lg text-blue-400">
+        회원이 아니신가요?&nbsp;
+        <Link href="/signup" className="underline text-black-500">
+          회원가입하기
+        </Link>
+      </p>
+      <SocialLogin />
+    </div>
+  );
+}

--- a/src/app/(with-header)/login/page.tsx
+++ b/src/app/(with-header)/login/page.tsx
@@ -1,3 +1,5 @@
+import LoginForm from "./_components/LoginForm";
+
 export default function Page() {
-  return <div>로그인 페이지</div>;
+  return <LoginForm />;
 }

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -40,7 +40,9 @@ export function Label({
 
 export function Error({ children }: PropsWithChildren) {
   return (
-    <span className="mt-1 lg:text-md text-sm text-red-500">{children}</span>
+    <span className="block mt-2 lg:text-md text-sm text-red-500">
+      {children}
+    </span>
   );
 }
 
@@ -70,7 +72,7 @@ export default function Input({
       <input
         id={id}
         className={cn(
-          "h-[44px] lg:h-[64px] rounded-xl text-black-950 mt-2 w-full placeholder:text-blue-400 text-lg lg:text-xl bg-blue-200 border p-3 focus:outline-2",
+          "h-[44px] lg:h-[64px] rounded-xl text-black-950 mt-4 w-full placeholder:text-blue-400 text-lg lg:text-xl bg-blue-200 border p-3 focus:outline-2",
           whiteBg ? "bg-white" : undefined,
           error
             ? "border-error-100 focus:outline-error-100"

--- a/src/components/SocialLogin.tsx
+++ b/src/components/SocialLogin.tsx
@@ -1,0 +1,29 @@
+import Image from "next/image";
+import google from "@/assets/social/google.svg";
+import kakao from "@/assets/social/kakao.svg";
+
+export default function SocialLogin() {
+  return (
+    <div>
+      <div className="mt-12 flex items-center gap-4">
+        <div className="flex-1 border-t border-blue-400" />
+        <p className="text-sm lg:text-lg text-blue-400 text-center font-medium">
+          SNS 계정으로 간편 로그인하기
+        </p>
+        <div className="flex-1 border-t border-blue-400" />
+      </div>
+      <div className="flex justify-center gap-4 mt-6">
+        <Image
+          src={google}
+          alt="구글 간편 로그인 아이콘"
+          className="w-[40px] h-[40px] lg:w-[60px] lg:h-[60px] cursor-pointer hover:grayscale-25"
+        />
+        <Image
+          src={kakao}
+          alt="카카오 간편 로그인 아이콘"
+          className="w-[40px] h-[40px] lg:w-[60px] lg:h-[60px] cursor-pointer hover:grayscale-25"
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## :hash: Issue

<!-- 이슈 번호를 작성해 주세요. -->
- close #12 
## :memo: Description

<!-- PR 내용을 불렛 형식으로 자세하게 작성해 주세요. -->
### 로그인 페이지 작업 내용입니다.

- 로고 클릭 시 랜딩 페이지("/")로 이동
- 로그인 성공 시, 메인 에피그램 페이지("/epigrams")로 이동
- 로그인 실패 시, 이메일 필드 오류 메시지에 "이메일 혹은 비밀번호를 확인해 주세요." 표시
- 이메일, 비밀번호 필드 유효성 검사
- 임시로 SocialLogin 컴포넌트를 공통 컴포넌트 폴더 안에 넣어두었음
- 추후 간편 로그인 로직 제작할 예정
- 로그인 성공 시, accessToken과 refreshToken 쿠키에 저장되는 것 확인
- 로그인 상태에서 로그인/회원가입 페이지 접근하면 메인 에피그램 페이지("/epigrams")로 리다이렉트
- 반응형 구현

![스크린샷 2025-04-29 153539](https://github.com/user-attachments/assets/01e8d932-2252-4fe7-ba7a-6e4f393a6850)
![스크린샷 2025-04-29 153555](https://github.com/user-attachments/assets/cf717fcb-780c-4720-a292-1e53304fe25e)


## :white_check_mark: Checklist

### PR Checklist

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] Assignee 및 Reviewer, 적절한 Label 지정
- [x] Development 설정

### Additional Notes

<!-- 추가 사항이 있을 경우, 작성해 주세요. -->

- [x] (없음)
