### PR TITLE
feat/26/공통컴포넌트 프로필 이미지

### DIFF
--- a/src/assets/icons/default-profile.svg
+++ b/src/assets/icons/default-profile.svg
@@ -1,11 +1,11 @@
 <svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_1350_12754)">
-<circle cx="24" cy="24" r="23.5" fill="white" stroke="#CBD3E1"/>
+<g clip-path="url(#clip0_1587_4439)">
+<circle cx="24" cy="24" r="24" fill="white"/>
 <circle cx="24" cy="15" r="7" fill="#ECEFF4"/>
 <path d="M10 33C10 28.5817 13.5817 25 18 25H30C34.4183 25 38 28.5817 38 33V35C38 37.2091 36.2091 39 34 39H14C11.7909 39 10 37.2091 10 35V33Z" fill="#ECEFF4"/>
 </g>
 <defs>
-<clipPath id="clip0_1350_12754">
+<clipPath id="clip0_1587_4439">
 <rect width="48" height="48" fill="white"/>
 </clipPath>
 </defs>

--- a/src/components/ProfileImage.tsx
+++ b/src/components/ProfileImage.tsx
@@ -1,0 +1,55 @@
+"use client";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/cn";
+import Image from "next/image";
+import defaultProfile from "@/assets/icons/default-profile.svg";
+
+const profileImageVariants = cva(
+  "relative rounded-full border border-blue-300",
+  {
+    variants: {
+      size: {
+        small: "w-[28px] h-[28px] lg:w-[36px] lg:h-[36px]",
+        medium: "w-[48px] h-[48px]",
+        large: "w-[80px] h-[80px] lg:w-[140px] lg:h-[140px]",
+      },
+      clickable: {
+        true: "cursor-pointer hover:brightness-90",
+        false: "cursor-default",
+      },
+    },
+    defaultVariants: {
+      size: "medium",
+      clickable: false,
+    },
+  }
+);
+
+interface ProfileImageProps extends VariantProps<typeof profileImageVariants> {
+  src: string | null;
+  className?: string;
+  clickable?: boolean;
+  onClick?: () => void;
+}
+
+export default function ProfileImage({
+  src,
+  size,
+  clickable,
+  className,
+  onClick,
+}: ProfileImageProps) {
+  return (
+    <div
+      className={cn(profileImageVariants({ size, clickable }), className)}
+      onClick={clickable ? onClick : undefined}
+    >
+      <Image
+        className="rounded-full object-cover"
+        src={src || defaultProfile}
+        alt="프로필 이미지"
+        fill
+      />
+    </div>
+  );
+}

--- a/src/stories/ProfileImage.stories.tsx
+++ b/src/stories/ProfileImage.stories.tsx
@@ -6,6 +6,8 @@ const meta: Meta<typeof ProfileImage> = {
   component: ProfileImage,
   tags: ["autodocs"],
   argTypes: {
+    src: { control: "text" },
+    size: { control: "radio", options: ["small", "medium", "large"] },
     onClick: { action: "clicked" },
   },
 };
@@ -29,7 +31,6 @@ export const Medium: Story = {
 
 export const Large: Story = {
   args: {
-    src: null,
     size: "large",
     clickable: true,
   },

--- a/src/stories/ProfileImage.stories.tsx
+++ b/src/stories/ProfileImage.stories.tsx
@@ -1,0 +1,36 @@
+import { Meta, StoryObj } from "@storybook/react";
+import ProfileImage from "@/components/ProfileImage";
+
+const meta: Meta<typeof ProfileImage> = {
+  title: "ProfileImage",
+  component: ProfileImage,
+  tags: ["autodocs"],
+  argTypes: {
+    onClick: { action: "clicked" },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ProfileImage>;
+
+export const Small: Story = {
+  args: {
+    size: "small",
+    clickable: false,
+  },
+};
+
+export const Medium: Story = {
+  args: {
+    size: "medium",
+    clickable: false,
+  },
+};
+
+export const Large: Story = {
+  args: {
+    src: null,
+    size: "large",
+    clickable: true,
+  },
+};


### PR DESCRIPTION
## :hash: Issue

<!-- 이슈 번호를 작성해 주세요. -->
- close #26 

## :memo: Description

<!-- PR 내용을 불렛 형식으로 자세하게 작성해 주세요. -->
### 공통 컴포넌트 프로필 이미지 컴포넌트 작업 내용입니다. ###
- 로그인 상태의 헤더, 메인 에피그램 페이지 및 마이 페이지의 댓글 컴포넌트에 사용됨
- src가 빈 값(프로필 이미지가 없을 때)일 경우 defaultProfile 이미지 값을 불러오도록 설정함
- size는 small(헤더), medium(댓글), large(마이 페이지)
- clickable, className, onClick 옵셔널
- clickable이 true가 아닐 시 onClick도 false
- 스토리북 구현
  - 스토리북에서 스웨거에서 받아온 이미지 url을 src에 문자열 형식으로 첨부하면 확인 가능 

![스크린샷 2025-05-02 192509](https://github.com/user-attachments/assets/10f3c281-ebc5-40aa-abe8-bf7707f5c55f)
![스크린샷 2025-05-02 192520](https://github.com/user-attachments/assets/20821c6f-b941-4585-8bf9-4ad78a3968fa)
## :white_check_mark: Checklist

### PR Checklist

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] Assignee 및 Reviewer, 적절한 Label 지정
- [x] Development 설정

### Additional Notes

<!-- 추가 사항이 있을 경우, 작성해 주세요. -->

- [x] (없음)
