### PR TITLE
feat/23/공통컴포넌트 로그인 상태 헤더

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,15 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  reactStrictMode: true,
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "sprint-fe-project.s3.ap-northeast-2.amazonaws.com",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/app/(with-header)/login/_components/LoginForm.tsx
+++ b/src/app/(with-header)/login/_components/LoginForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useForm } from "react-hook-form";
 import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useLogin } from "@/lib/hooks/useAuth";
@@ -17,6 +18,7 @@ import SocialLogin from "@/components/SocialLogin";
 export default function LoginForm() {
   const { mutateAsync: login } = useLogin();
   const router = useRouter();
+  const queryClient = useQueryClient();
   const [isShowPassword, setIsShowPassword] = useState(false);
   const {
     register,
@@ -32,6 +34,7 @@ export default function LoginForm() {
   const onSubmit = async (data: LoginRequest) => {
     try {
       await login(data);
+      await queryClient.invalidateQueries({ queryKey: ["users"] });
       router.push("/epigrams");
     } catch (error) {
       console.error("로그인 실패", error);

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,14 @@
+"use client";
+import { useMyData } from "@/lib/hooks/useUsers";
+import LoggedInHeader from "./LoggedInHeader";
 import LoggedOutHeader from "./LoggedOutHeader";
 
 export default function Header() {
-  return <LoggedOutHeader />;
+  const { data: user } = useMyData();
+
+  return user ? (
+    <LoggedInHeader nickname={user.nickname} image={user.image} />
+  ) : (
+    <LoggedOutHeader />
+  );
 }

--- a/src/components/LoggedInHeader.tsx
+++ b/src/components/LoggedInHeader.tsx
@@ -1,0 +1,104 @@
+import { useRef, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { useClickOutside } from "@/lib/utils/useClickOutside";
+import Link from "next/link";
+import Image from "next/image";
+import logoSm from "@/assets/logo/logo-sm.svg";
+import menu from "@/assets/icons/menu.svg";
+import xGray from "@/assets/icons/x-gray.svg";
+import ProfileImage from "./ProfileImage";
+
+export default function LoggedInHeader({
+  nickname,
+  image,
+}: {
+  nickname: string;
+  image: string | null;
+}) {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const menuRef = useRef(null);
+  const closeMenu = () => setIsMenuOpen(false);
+  useClickOutside(menuRef, () => setIsMenuOpen(false));
+
+  return (
+    <header className="fixed w-full bg-blue-100 border-b border-gray-100 z-50">
+      <div className="relative px-4 md:px-6 max-w-[1480px] mx-auto h-[52px] md:h-[70px] lg:h-[80px] flex items-center justify-between">
+        <div className="flex gap-2 md:gap-6 items-center">
+          <Image
+            src={menu}
+            className="md:hidden cursor-pointer"
+            width={24}
+            height={24}
+            alt="메뉴 열기 아이콘"
+            aria-label="메뉴 열기"
+            onClick={() => setIsMenuOpen(true)}
+          />
+          <Link href="/">
+            <Image
+              src={logoSm}
+              alt="로고"
+              className="w-[101px] h-[26px] lg:w-[132px] lg:h-[36px]"
+            />
+          </Link>
+          <Link
+            href="/feeds"
+            className="hidden md:block font-semibold text-md lg:text-lg text-black-600"
+          >
+            피드
+          </Link>
+          <Link
+            href="/search"
+            className="hidden md:block font-semibold text-md lg:text-lg text-black-600"
+          >
+            검색
+          </Link>
+        </div>
+        <Link href="/mypage" className="flex gap-2 items-center">
+          <ProfileImage src={image} size="small" clickable />
+          <p className="font-semibold text-md lg:text-lg text-black-600">
+            {nickname}
+          </p>
+        </Link>
+      </div>
+
+      <AnimatePresence>
+        {isMenuOpen && (
+          <motion.div
+            className="fixed inset-0 bg-black/40 z-40"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0, transition: { duration: 0.15 } }}
+            transition={{ duration: 0.3 }}
+          >
+            <motion.div
+              className="relative bg-blue-100 w-[220px] h-full p-4"
+              ref={menuRef}
+              initial={{ x: "-100%" }}
+              animate={{ x: 0 }}
+              exit={{ x: "-100%" }}
+              transition={{ type: "tween", duration: 0.3 }}
+            >
+              <Image
+                src={xGray}
+                width={24}
+                height={24}
+                alt="메뉴 닫기 아이콘"
+                className="absolute top-4 right-4 cursor-pointer"
+                aria-label="메뉴 닫기"
+                onClick={closeMenu}
+              />
+              <div className="absolute top-8 pl-2 text-black-600 text-lg font-semibold">
+                <Link href="/feeds" className="block py-12" onClick={closeMenu}>
+                  피드
+                </Link>
+                <Link href="/search" onClick={closeMenu}>
+                  검색
+                </Link>
+              </div>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </header>
+  );
+}

--- a/src/components/LoggedOutHeader.tsx
+++ b/src/components/LoggedOutHeader.tsx
@@ -1,4 +1,3 @@
-"use client";
 import { usePathname } from "next/navigation";
 import Image from "next/image";
 import Link from "next/link";

--- a/src/components/LoggedOutHeader.tsx
+++ b/src/components/LoggedOutHeader.tsx
@@ -11,38 +11,36 @@ export default function LoggedOutHeader() {
   const isAuthPage = pathname == "/login" || pathname === "/signup";
 
   return (
-    <>
-      <header className="fixed w-full bg-blue-100 border-b border-gray-100 z-50">
-        <div className="relative px-4 max-w-[1480px] mx-auto h-[52px] md:h-[70px] lg:h-[80px] flex items-center">
-          {!isAuthPage && (
-            <Link href="/search" className="absolute left-4">
-              <Image
-                src={search}
-                alt="검색 아이콘"
-                className="w-[20px] lg:w-[28px]"
-              />
-            </Link>
-          )}
-
-          <Link href="/" className="absolute left-1/2 -translate-x-1/2">
+    <header className="fixed w-full bg-blue-100 border-b border-gray-100 z-50">
+      <div className="relative px-4 md:px-6 max-w-[1480px] mx-auto h-[52px] md:h-[70px] lg:h-[80px] flex items-center">
+        {!isAuthPage && (
+          <Link href="/search" className="absolute left-4">
             <Image
-              src={logoSm}
-              alt="로고"
-              className="w-[101px] h-[26px] lg:w-[132px] lg:h-[36px]"
+              src={search}
+              alt="검색 아이콘"
+              className="w-[20px] lg:w-[28px]"
             />
           </Link>
+        )}
 
-          {!isAuthPage && (
-            <Link href="/mypage" className="absolute right-4">
-              <Image
-                src={user}
-                alt="유저 아이콘"
-                className="w-[20px] lg:w-[28px]"
-              />
-            </Link>
-          )}
-        </div>
-      </header>
-    </>
+        <Link href="/" className="absolute left-1/2 -translate-x-1/2">
+          <Image
+            src={logoSm}
+            alt="로고"
+            className="w-[101px] h-[26px] lg:w-[132px] lg:h-[36px]"
+          />
+        </Link>
+
+        {!isAuthPage && (
+          <Link href="/mypage" className="absolute right-4">
+            <Image
+              src={user}
+              alt="유저 아이콘"
+              className="w-[20px] lg:w-[28px]"
+            />
+          </Link>
+        )}
+      </div>
+    </header>
   );
 }

--- a/src/lib/utils/useClickOutside.tsx
+++ b/src/lib/utils/useClickOutside.tsx
@@ -1,0 +1,22 @@
+import { useEffect } from "react";
+
+export function useClickOutside(
+  ref: React.RefObject<HTMLElement | null>,
+  handler: () => void
+) {
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent | TouchEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        handler();
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("touchstart", handleClickOutside);
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("touchstart", handleClickOutside);
+    };
+  }, [ref, handler]);
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { cookies } from "next/headers";
 
-const AFTER_LOGIN_DOMAIN = ["/mypage"] satisfies readonly string[];
+const AFTER_LOGIN_DOMAIN = ["/mypage", "/epigrams"] satisfies readonly string[];
 const BEFORE_LOGIN_DOMAIN = [
   "/",
   "/login",
@@ -16,7 +16,9 @@ export const middleware = async (request: NextRequest) => {
 
   const pathname = request.nextUrl.pathname.replace(/\/$/, "");
 
-  const isAfterLoginRoute = AFTER_LOGIN_DOMAIN.includes(pathname);
+  const isAfterLoginRoute = AFTER_LOGIN_DOMAIN.some((route) =>
+    pathname.startsWith(route)
+  );
   const isBeforeLoginRoute = BEFORE_LOGIN_DOMAIN.includes(pathname);
   const isLoggedIn = accessToken?.value || refreshToken?.value;
 


### PR DESCRIPTION
## :hash: Issue

<!-- 이슈 번호를 작성해 주세요. -->
- close #23 
## :memo: Description

<!-- PR 내용을 불렛 형식으로 자세하게 작성해 주세요. -->
### 공통 컴포넌트 로그인 상태 헤더 컴포넌트 작업 내용입니다. ###
- Header 컴포넌트에서 user 데이터 조회하여 조건부 렌더링
- 로그인 시, 새로고침 없이 로그인 상태의 헤더 컴포넌트 렌더링(프로필 이미지, 닉네임 표시)
- 모바일 화면 사이즈일 때 사이드 메뉴 레이아웃 구성
- 사이드 메뉴가 열려있을 때 외부 클릭 시 닫히도록(useClickOutside 함수 작성)
- 앞서 설치한 framer-motion 라이브러리를 사용해 슬라이드 메뉴에 부드러운 애니메이션 효과 적용
- next.config.ts 파일에 사용하는 이미지 주소 호스트명 추가

![스크린샷 2025-05-03 115824](https://github.com/user-attachments/assets/1466c7ef-715b-46a5-83fe-498384f91144)

https://github.com/user-attachments/assets/0ef44ea3-0ad3-47f3-a609-33b33f174a37




## :white_check_mark: Checklist

### PR Checklist

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] Assignee 및 Reviewer, 적절한 Label 지정
- [x] Development 설정

### Additional Notes

<!-- 추가 사항이 있을 경우, 작성해 주세요. -->

- [x] (없음)
