### PR TITLE
feat/29/피드페이지

### DIFF
--- a/src/app/(with-header)/addepigram/page.tsx
+++ b/src/app/(with-header)/addepigram/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>에피그램 작성 페이지</div>;
+}

--- a/src/app/(with-header)/epigrams/page.tsx
+++ b/src/app/(with-header)/epigrams/page.tsx
@@ -1,6 +1,7 @@
 import TodayEpigram from "./_components/TodayEpigram";
 import EmotionLogs from "@/components/EmotionLogs";
 import LatestEpigram from "./_components/LatestEpigram";
+import FloatingButton from "@/components/FloatingButton";
 
 export default function Page() {
   return (
@@ -17,6 +18,7 @@ export default function Page() {
         최신 에피그램
       </h2>
       <LatestEpigram />
+      <FloatingButton />
     </div>
   );
 }

--- a/src/app/(with-header)/feeds/_components/FeedsContainer.tsx
+++ b/src/app/(with-header)/feeds/_components/FeedsContainer.tsx
@@ -1,0 +1,89 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useEpigrams } from "@/lib/hooks/useEpigram";
+import EpigramItem from "@/components/EpigramItem";
+import Button from "@/components/Button";
+import Image from "next/image";
+import plus from "@/assets/icons/plus.svg";
+import sort from "@/assets/icons/sort.svg";
+import dashboard from "@/assets/icons/dashboard.svg";
+
+export default function FeedsContainer() {
+  const [limit, setLimit] = useState(6);
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [isGridTwo, setIsGridTwo] = useState(false);
+  const { data, isLoading, isError } = useEpigrams({
+    limit: limit,
+  });
+
+  useEffect(() => {
+    setIsLoaded(false);
+  }, [data?.list?.length]);
+
+  const handleLoadMore = async (e: React.MouseEvent) => {
+    e.preventDefault();
+
+    if (
+      !isLoaded &&
+      (data?.list?.length ?? 0) < (data?.totalCount ?? Infinity)
+    ) {
+      setLimit((prevLimit) => prevLimit + 6);
+      setIsLoaded(true);
+    }
+  };
+
+  if (isLoading) return <p>로딩 중...</p>;
+  if (isError) return <p>에러가 발생했습니다.</p>;
+
+  return (
+    <>
+      <div className="flex justify-between items-start">
+        <h2 className="text-black-600 font-semibold text-lg lg:text-xl mb-6 lg:mb-10">
+          피드
+        </h2>
+        <Image
+          src={isGridTwo ? sort : dashboard}
+          alt="2열로 보기"
+          width={28}
+          height={24}
+          className="md:hidden cursor-pointer"
+          onClick={() => setIsGridTwo((prev) => !prev)}
+        />
+      </div>
+      <div
+        className={`grid md:grid-cols-2 gap-4 md:gap-8 w-full h-full ${
+          isGridTwo ? "grid-cols-2" : "grid-cols-1 gap-6"
+        }`}
+      >
+        {data?.list.map((epigram) => (
+          <div key={epigram.id}>
+            <EpigramItem
+              id={epigram.id}
+              content={epigram.content}
+              author={epigram.author}
+              tags={epigram.tags}
+              isFeedPage
+            />
+          </div>
+        ))}
+      </div>
+
+      {(data?.list?.length ?? 0) < (data?.totalCount ?? Infinity) && (
+        <Button
+          variant="outline"
+          size="xl"
+          isRoundedFull
+          className="mx-auto mt-14 lg:mt-20 w-[152px] lg:w-[240px]"
+          onClick={handleLoadMore}
+        >
+          <Image
+            src={plus}
+            alt="더보기 아이콘"
+            className="lg:mr-2 w-[20px] lg:w-[24px]"
+          />
+          에피그램 더보기
+        </Button>
+      )}
+    </>
+  );
+}

--- a/src/app/(with-header)/feeds/page.tsx
+++ b/src/app/(with-header)/feeds/page.tsx
@@ -1,3 +1,13 @@
+import FloatingButton from "@/components/FloatingButton";
+import FeedsContainer from "./_components/FeedsContainer";
+
 export default function Page() {
-  return <div className="font-iropke">피드 페이지</div>;
+  return (
+    <>
+      <div className="max-w-[1200px] mx-auto mt-[32px] lg:mt-[120px] max-[1250px]:px-6 min-[1251px]:px-0 mb-[140px]">
+        <FeedsContainer />
+      </div>
+      <FloatingButton />
+    </>
+  );
 }

--- a/src/assets/icons/dashboard.svg
+++ b/src/assets/icons/dashboard.svg
@@ -1,6 +1,6 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect x="5" y="5" width="6" height="6" rx="1" fill="#C4C4C4"/>
-<rect x="5" y="13" width="6" height="6" rx="1" fill="#C4C4C4"/>
-<rect x="13" y="13" width="6" height="6" rx="1" fill="#C4C4C4"/>
-<rect x="13" y="5" width="6" height="6" rx="1" fill="#C4C4C4"/>
+<svg width="28" height="24" viewBox="0 0 28 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="5.8335" y="5" width="7" height="6" rx="1" fill="#C4C4C4"/>
+<rect x="5.8335" y="13" width="7" height="6" rx="1" fill="#C4C4C4"/>
+<rect x="15.1665" y="13" width="7" height="6" rx="1" fill="#C4C4C4"/>
+<rect x="15.1665" y="5" width="7" height="6" rx="1" fill="#C4C4C4"/>
 </svg>

--- a/src/components/EpigramItem.tsx
+++ b/src/components/EpigramItem.tsx
@@ -25,8 +25,11 @@ export default function EpigramItem({
       >
         <div
           className={clsx(
-            "relative rounded-2xl h-auto p-4 md:p-6 bg-blue-100 border border-line-100 transition-transform duration-200 ease-in-out transform hover:scale-102",
-            { "lg:h-[260px] md:h-[180px] h-[140px]": isFeedPage }
+            "relative rounded-2xl p-4 md:p-6 bg-blue-100 border border-line-100 transition-transform duration-200 ease-in-out transform hover:scale-102",
+            {
+              "lg:h-[260px] md:h-[180px] h-[140px]": isFeedPage,
+              "h-auto": !isFeedPage,
+            }
           )}
           style={{ boxShadow: "0px 3px 12px 0px rgba(0, 0, 0, 0.04)" }}
         >
@@ -41,7 +44,7 @@ export default function EpigramItem({
           <div className="z-10 relative h-full flex flex-col justify-between">
             <div
               className={clsx("text-md lg:text-lg font-medium text-black-600", {
-                "line-clamp-1 md:line-clamp-3 lg:line-clamp-none break-keep overflow-hidden":
+                "line-clamp-2 md:line-clamp-3 lg:line-clamp-none break-keep overflow-hidden":
                   isFeedPage,
               })}
             >

--- a/src/components/FloatingButton.tsx
+++ b/src/components/FloatingButton.tsx
@@ -1,0 +1,40 @@
+"use client";
+import { scrollToTop } from "@/lib/utils/scrollToTop";
+import Button from "@/components/Button";
+import Image from "next/image";
+import plusWhite from "@/assets/icons/plus-white.svg";
+import chevronUpWhite from "@/assets/icons/chevron-up-white.svg";
+
+export default function FloatingButton() {
+  return (
+    <>
+      <Button
+        variant="secondary"
+        size="xl"
+        className="w-[152px] lg:w-[194px] fixed bottom-[90px] lg:bottom-[120px] right-[24px] md:right-[32px] z-50 shadow-lg"
+        href="/addepigram"
+        isRoundedFull
+      >
+        <Image
+          src={plusWhite}
+          alt="만들기 아이콘"
+          className="lg:mr-2 w-[20px] lg:w-[24px]"
+        />
+        에피그램 만들기
+      </Button>
+      <Button
+        variant="secondary"
+        size="xl"
+        className="w-[48px] lg:w-[64px] fixed p-0 bottom-[32px] right-[24px] md:right-[32px] z-50 shadow-lg"
+        onClick={scrollToTop}
+        isRoundedFull
+      >
+        <Image
+          src={chevronUpWhite}
+          alt="상단 이동 아이콘"
+          className="w-[20px] lg:w-[24px]"
+        />
+      </Button>
+    </>
+  );
+}

--- a/src/lib/utils/scrollToTop.tsx
+++ b/src/lib/utils/scrollToTop.tsx
@@ -1,0 +1,6 @@
+export const scrollToTop = () => {
+  window.scrollTo({
+    top: 0,
+    behavior: "smooth",
+  });
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { cookies } from "next/headers";
 
-const AFTER_LOGIN_DOMAIN = ["/mypage", "/epigrams"] satisfies readonly string[];
+const AFTER_LOGIN_DOMAIN = [
+  "/mypage",
+  "/addepigram",
+  "/epigrams",
+] satisfies readonly string[];
 const BEFORE_LOGIN_DOMAIN = [
   "/",
   "/login",


### PR DESCRIPTION
## :hash: Issue

<!-- 이슈 번호를 작성해 주세요. -->
- close #29 
## :memo: Description

<!-- PR 내용을 불렛 형식으로 자세하게 작성해 주세요. -->
### 피드 페이지 작업 내용입니다. ###
- FeedContainer 컴포넌트를 만들어 에피그램 목록 조회 훅을 불러와 6개씩 렌더링하도록 하였으며 "에피그램 더보기" 버튼 클릭 시 6개씩 추가됨
- 더 불러올 데이터가 없을 경우 "에피그램 더보기" 버튼은 사라짐
- PC와 태블릿 환경에서는 2열 형식, 모바일 환경에서는 기본 1열 형식, dashboard 이미지 클릭 시에 2열 형식으로 변환되며 토글 형식으로 바꾸어 선택 가능
- 반응형 구현
- 추후 데이터 더 불러올 때 새로고침되며 아예 새 데이터 요청해버리는 버그 수정 필요
- FloatingButton 컴포넌트를 만들어 피드 페이지와 메인 에피그램 페이지에 배치하였음
  - 만약 비로그인 상태에서 "에피그램 만들기" 버튼 클릭 시, 로그인 페이지로 이동하도록 middleware.ts 파일에서 경로 추가(에피그램 작성 페이지 (/addepigram))
  - 상단 이동 버튼을 위해 lib/utils/scrollToTop 함수 파일 추가

PC
![스크린샷 2025-05-04 104600](https://github.com/user-attachments/assets/719c0fea-cf0c-43c4-b61e-93bb6a3f2b30)

Tablet
![스크린샷 2025-05-04 104616](https://github.com/user-attachments/assets/e3c09752-0d23-42de-9e79-f3aa5cc00740)

모바일 1열
![스크린샷 2025-05-04 104625](https://github.com/user-attachments/assets/81d33318-6895-4622-b81c-764a3b7ec32e)

모바일 2열
![스크린샷 2025-05-04 104633](https://github.com/user-attachments/assets/4e9e6637-b55c-400a-be54-d73edaaf08ae)

## :white_check_mark: Checklist

### PR Checklist

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] Assignee 및 Reviewer, 적절한 Label 지정
- [x] Development 설정

### Additional Notes

<!-- 추가 사항이 있을 경우, 작성해 주세요. -->

- [x] (없음)
