### PR TITLE
feat/33/공통컴포넌트 댓글

### DIFF
--- a/src/app/(with-header)/epigrams/_components/CommentList.tsx
+++ b/src/app/(with-header)/epigrams/_components/CommentList.tsx
@@ -1,0 +1,81 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useCommentList } from "@/lib/hooks/useComments";
+import { useMyData } from "@/lib/hooks/useUsers";
+import { UpdateCommentResponse } from "@/lib/types/comments";
+import CommentItem from "@/components/CommentItem";
+import Button from "@/components/Button";
+import Image from "next/image";
+import plus from "@/assets/icons/plus.svg";
+
+export default function CommentList() {
+  const [limit, setLimit] = useState(3);
+  const { data, isLoading, isError } = useCommentList({
+    limit: limit,
+  });
+  const { data: user } = useMyData();
+  const [commentList, setCommentList] = useState(data?.list || []);
+
+  useEffect(() => {
+    if (data?.list) {
+      setCommentList(data.list);
+    }
+  }, [data]);
+
+  const handleLoadMore = (e: React.MouseEvent) => {
+    e.preventDefault();
+
+    if ((commentList.length ?? 0) < (data?.totalCount ?? Infinity)) {
+      setLimit((prevLimit) => prevLimit + 3);
+    }
+  };
+
+  const handleUpdateComment = (updatedComment: UpdateCommentResponse) => {
+    setCommentList((prevList) =>
+      prevList.map((comment) =>
+        comment.id === updatedComment.id ? updatedComment : comment
+      )
+    );
+  };
+
+  if (isLoading) return <p>로딩 중...</p>;
+  if (isError) return <p>에러가 발생했습니다.</p>;
+
+  return (
+    <>
+      <div className="mt-10">
+        {commentList.map((comment) => (
+          <div key={comment.id}>
+            <CommentItem
+              epigramId={comment.epigramId}
+              commentId={comment.id}
+              image={comment.writer.image}
+              nickname={comment.writer.nickname}
+              content={comment.content}
+              updatedAt={comment.updatedAt}
+              isMine={user?.id === comment.writer.id}
+              onUpdate={handleUpdateComment}
+            />
+          </div>
+        ))}
+      </div>
+
+      {(commentList.length ?? 0) < (data?.totalCount ?? Infinity) && (
+        <Button
+          variant="outline"
+          size="xl"
+          isRoundedFull
+          className="mx-auto mt-14 w-[152px] lg:w-[240px]"
+          onClick={handleLoadMore}
+        >
+          <Image
+            src={plus}
+            alt="더보기 아이콘"
+            className="lg:mr-2 w-[20px] lg:w-[24px]"
+          />
+          최신 댓글 더보기
+        </Button>
+      )}
+    </>
+  );
+}

--- a/src/app/(with-header)/epigrams/page.tsx
+++ b/src/app/(with-header)/epigrams/page.tsx
@@ -1,11 +1,12 @@
 import TodayEpigram from "./_components/TodayEpigram";
 import EmotionLogs from "@/components/EmotionLogs";
 import LatestEpigram from "./_components/LatestEpigram";
+import CommentList from "./_components/CommentList";
 import FloatingButton from "@/components/FloatingButton";
 
 export default function Page() {
   return (
-    <div className="max-w-[640px] mx-auto mt-[32px] lg:mt-[120px] px-6 md:px-0 mb-24">
+    <div className="max-w-[640px] mx-auto mt-[32px] lg:mt-[120px] px-6 md:px-0 mb-32">
       <h2 className="text-black-600 font-semibold text-lg lg:text-xl mb-6 lg:mb-10">
         오늘의 에피그램
       </h2>
@@ -18,6 +19,10 @@ export default function Page() {
         최신 에피그램
       </h2>
       <LatestEpigram />
+      <h2 className="text-black-600 font-semibold text-lg lg:text-xl mt-14 lg:mt-35 mb-6 lg:mb-10">
+        최신 댓글
+      </h2>
+      <CommentList />
       <FloatingButton />
     </div>
   );

--- a/src/components/CommentItem.tsx
+++ b/src/components/CommentItem.tsx
@@ -1,0 +1,133 @@
+import { useState } from "react";
+import { useDeleteComment, useUpdateComment } from "@/lib/hooks/useComments";
+import { UpdateCommentResponse } from "@/lib/types/comments";
+import formatTime from "@/lib/utils/formatTime";
+import Link from "next/link";
+import ProfileImage from "./ProfileImage";
+import Button from "./Button";
+
+interface CommentItemProps {
+  epigramId?: number;
+  commentId: number;
+  image: string | null;
+  nickname: string;
+  updatedAt: string;
+  content: string;
+  isMine: boolean;
+  isPrivate?: boolean;
+  onUpdate: (updatedComment: UpdateCommentResponse) => void;
+}
+
+export default function CommentItem({
+  epigramId,
+  commentId,
+  image,
+  nickname,
+  updatedAt,
+  content,
+  isMine,
+  onUpdate,
+}: CommentItemProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editedContent, setEditedContent] = useState(content);
+  const updateComment = useUpdateComment(commentId);
+  const deleteComment = useDeleteComment();
+
+  const handleSave = () => {
+    if (editedContent.trim() === "") return;
+    updateComment.mutate(
+      { content: editedContent, isPrivate: false },
+      {
+        onSuccess: (updateComment) => {
+          onUpdate(updateComment);
+          setIsEditing(false);
+        },
+      }
+    );
+  };
+
+  const handleCancel = () => {
+    setEditedContent(content);
+    setIsEditing(false);
+  };
+
+  return (
+    <>
+      <hr className="border-line-200" />
+      <div className="my-4 px-4 flex gap-4">
+        <ProfileImage
+          size="medium"
+          src={image}
+          clickable
+          className="w-[48px] h-[48px] aspect-square"
+        />
+        <div className="w-full">
+          <div className="flex justify-between">
+            <p className="text-black-300 text-xs md:text-md">
+              {nickname} &nbsp; {formatTime(updatedAt)}
+            </p>
+
+            {isMine && !isEditing && (
+              <div className="flex gap-4 text-xs">
+                <p
+                  className="text-black-600 underline cursor-pointer"
+                  onClick={() => setIsEditing(true)}
+                >
+                  수정
+                </p>
+                <p
+                  className="text-error-100 underline cursor-pointer"
+                  onClick={() => deleteComment.mutate(commentId)}
+                >
+                  삭제
+                </p>
+              </div>
+            )}
+          </div>
+
+          {isMine && isEditing ? (
+            <>
+              <textarea
+                value={editedContent}
+                onChange={(e) => setEditedContent(e.target.value)}
+                className={`mt-2 w-full border rounded-md p-2 text-black-700 border-black-600 text-sm ${
+                  editedContent.trim() === ""
+                    ? "outline-error-100 border-error-100"
+                    : "outline-black-600"
+                }`}
+                placeholder={`${
+                  editedContent.trim() === "" ? "100자 이내로 입력하세요." : ""
+                }`}
+                rows={3}
+              />
+              <div className="flex justify-end gap-2">
+                <Button
+                  size="sm"
+                  onClick={handleSave}
+                  className="w-[52px] lg:w-[60px]"
+                  disabled={editedContent.trim() === ""}
+                >
+                  저장
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="w-[52px] lg:w-[60px]"
+                  onClick={handleCancel}
+                >
+                  취소
+                </Button>
+              </div>
+            </>
+          ) : epigramId ? (
+            <Link href={`/epigrams/${epigramId}`}>
+              <p className="mt-2 text-black-700 text-md">{content}</p>
+            </Link>
+          ) : (
+            <p className="mt-2 text-black-700 text-md">{content}</p>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/CommentItem.tsx
+++ b/src/components/CommentItem.tsx
@@ -14,7 +14,6 @@ interface CommentItemProps {
   updatedAt: string;
   content: string;
   isMine: boolean;
-  isPrivate?: boolean;
   onUpdate: (updatedComment: UpdateCommentResponse) => void;
 }
 

--- a/src/components/EpigramItem.tsx
+++ b/src/components/EpigramItem.tsx
@@ -17,7 +17,7 @@ export default function EpigramItem({
   isFeedPage = false,
 }: EpigramItemProps) {
   return (
-    <Link href={`/epigrams/${id}`} className="font-iropke">
+    <Link href={`/epigrams/${id}`}>
       <div
         className={clsx("font-iropke", {
           "max-w-[640px]": !isFeedPage,

--- a/src/lib/utils/formatTime.tsx
+++ b/src/lib/utils/formatTime.tsx
@@ -1,0 +1,36 @@
+export default function formatTime(createdAt: string): string {
+  const now = new Date();
+  const createdDate = new Date(createdAt);
+  const diffInSeconds = Math.floor(
+    (now.getTime() - createdDate.getTime()) / 1000
+  );
+
+  const rtf = new Intl.RelativeTimeFormat("ko", { numeric: "auto" });
+
+  if (diffInSeconds < 60) {
+    return "방금 전";
+  }
+
+  const diffInMinutes = Math.floor(diffInSeconds / 60);
+  if (diffInMinutes < 60) {
+    return rtf.format(-diffInMinutes, "minute"); // X분 전
+  }
+
+  const diffInHours = Math.floor(diffInMinutes / 60);
+  if (diffInHours < 24) {
+    return rtf.format(-diffInHours, "hour"); // X시간 전
+  }
+
+  const diffInDays = Math.floor(diffInHours / 24);
+  if (diffInDays < 30) {
+    return rtf.format(-diffInDays, "day"); // X일 전
+  }
+
+  const diffInMonths = Math.floor(diffInDays / 30);
+  if (diffInMonths < 12) {
+    return rtf.format(-diffInMonths, "month"); // X개월 전
+  }
+
+  const diffInYears = Math.floor(diffInMonths / 12);
+  return rtf.format(-diffInYears, "year"); // X년 전
+}


### PR DESCRIPTION
## :hash: Issue

<!-- 이슈 번호를 작성해 주세요. -->
- close #33 
## :memo: Description

<!-- PR 내용을 불렛 형식으로 자세하게 작성해 주세요. -->
### 공통 컴포넌트 댓글 컴포넌트 작업 내용입니다. ###
- 반응형 구현
- 유저 프로필 이미지, 닉네임, 댓글 작성 시간을 렌더링함
- epigramId 옵셔널 prop을 작성할 경우 Link 컴포넌트로 연결하여 해당 댓글이 있는 에피그램 상세 페이지로 이동
  - 작성하지 않는 경우는 에피그램 상세 페이지에서 렌더링하는 댓글 목록
  - 댓글 영역에 클릭해야 이동함(content)
 - commentId prop을 받고 있으며 해당 댓글 id로 수정/삭제 기능
   - 수정 시, 바로 textarea가 렌더링되어 기존 댓글에서 수정 가능하며 내용이 비었을 경우 placeholder("100자 이내로 입력하세요."), outline 설정 및 버튼 disabled 처리
   - 수정 시, 새로고침 없이 즉시 반영
   - 추후 삭제 시, 확인 모달이 나타나야 함(현재는 즉시 삭제되고 있음)
- useMyData 커스텀 훅을 불러와 현재 로그인한 유저가 작성한 댓글인지 판단하여 isMine prop을 전달함
- 시간 포맷 formatTime 함수 파일을 작성하여 updatedAt을 받아 시간을 계산하여 알맞게 표시함(createdAt, UpdatedAt 둘 다 최초 댓글 작성 시 시간이 저장되고, 그후 수정했을 때는 updatedAt만 사용하므로 updatedAt 응답만 사용함)
- 메인 에피그램 페이지에서는 비공개 댓글은 데이터로 갖고 있지 않으며 추후 isPrivate prop 추가하여 토글 UI 제작 예정
- 추후 유저 프로필 이미지 클릭 시, 유저 정보 모달이 나타나야 함
- 최신 댓글 컴포넌트인 CommentList에서 초기 3개의 댓글을 렌더링하며 "최신 댓글 더보기" 버튼 클릭 시 3개씩 추가로 불러옴(더 불러올 댓글 데이터가 없을 경우 버튼 표시되지 않음)

![스크린샷 2025-05-04 192440](https://github.com/user-attachments/assets/3553f71a-2d8d-45a9-afd0-ef0f6102d8c8)
![스크린샷 2025-05-04 192416](https://github.com/user-attachments/assets/fcded204-cdcf-4338-9504-cb9480095939)
![스크린샷 2025-05-04 192357](https://github.com/user-attachments/assets/1487c790-c145-4871-a65b-8e030fd3c1af)

## :white_check_mark: Checklist

### PR Checklist

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] Assignee 및 Reviewer, 적절한 Label 지정
- [x] Development 설정

### Additional Notes

<!-- 추가 사항이 있을 경우, 작성해 주세요. -->

- [x] (없음)
