### PR TITLE
feat/35/공통컴포넌트 모달

### DIFF
--- a/src/app/(with-header)/epigrams/_components/CommentList.tsx
+++ b/src/app/(with-header)/epigrams/_components/CommentList.tsx
@@ -38,6 +38,12 @@ export default function CommentList() {
     );
   };
 
+  const handleDeleteComment = (id: number) => {
+    setCommentList((prevList) =>
+      prevList.filter((comment) => comment.id !== id)
+    );
+  };
+
   if (isLoading) return <p>로딩 중...</p>;
   if (isError) return <p>에러가 발생했습니다.</p>;
 
@@ -55,6 +61,7 @@ export default function CommentList() {
               updatedAt={comment.updatedAt}
               isMine={user?.id === comment.writer.id}
               onUpdate={handleUpdateComment}
+              onDelete={handleDeleteComment}
             />
           </div>
         ))}

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -17,9 +17,9 @@ const buttonVariants = cva(
       },
       size: {
         sm: "h-[32px] lg:h-[44px] text-xs lg:text-lg px-3 rounded-[8px]",
-        md: "h-[36px] lg:h-[48px] text-md lg:text-xl px-3 rounded-[12px]",
-        lg: "h-[42px] lg:h-[56px] text-lg lg:text-xl px-4 rounded-[16px]",
-        xl: "h-[48px] lg:h-[64px] text-lg lg:text-xl px-4 rounded-[16px]",
+        md: "h-[42px] lg:h-[48px] text-md lg:text-2lg px-3 rounded-[12px]",
+        lg: "h-[42px] lg:h-[56px] text-lg lg:text-2lg px-4 rounded-[16px]",
+        xl: "h-[48px] lg:h-[64px] text-lg lg:text-2lg px-4 rounded-[16px]",
       },
       disabled: {
         true: "cursor-not-allowed",

--- a/src/components/CommentItem.tsx
+++ b/src/components/CommentItem.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { useState } from "react";
 import { useDeleteComment, useUpdateComment } from "@/lib/hooks/useComments";
 import { UpdateCommentResponse } from "@/lib/types/comments";
@@ -5,6 +6,9 @@ import formatTime from "@/lib/utils/formatTime";
 import Link from "next/link";
 import ProfileImage from "./ProfileImage";
 import Button from "./Button";
+import Modal from "./Modal";
+import UserInfoModal from "./UserInfoModal";
+import DeleteItemModal from "./DeleteItemModal";
 
 interface CommentItemProps {
   epigramId?: number;
@@ -15,6 +19,7 @@ interface CommentItemProps {
   content: string;
   isMine: boolean;
   onUpdate: (updatedComment: UpdateCommentResponse) => void;
+  onDelete: (id: number) => void;
 }
 
 export default function CommentItem({
@@ -26,9 +31,12 @@ export default function CommentItem({
   content,
   isMine,
   onUpdate,
+  onDelete,
 }: CommentItemProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [editedContent, setEditedContent] = useState(content);
+  const [isUserInfoModalOpen, setIsUserInfoModalOpen] = useState(false);
+  const [isDeleteItemModalOpen, setIsDeleteItemModalOpen] = useState(false);
   const updateComment = useUpdateComment(commentId);
   const deleteComment = useDeleteComment();
 
@@ -45,6 +53,14 @@ export default function CommentItem({
     );
   };
 
+  const handleDeleteCommentItem = () => {
+    deleteComment.mutate(commentId, {
+      onSuccess: () => {
+        onDelete?.(commentId);
+      },
+    });
+  };
+
   const handleCancel = () => {
     setEditedContent(content);
     setIsEditing(false);
@@ -55,10 +71,11 @@ export default function CommentItem({
       <hr className="border-line-200" />
       <div className="my-4 px-4 flex gap-4">
         <ProfileImage
-          size="medium"
+          size="md"
           src={image}
           clickable
           className="w-[48px] h-[48px] aspect-square"
+          onClick={() => setIsUserInfoModalOpen(true)}
         />
         <div className="w-full">
           <div className="flex justify-between">
@@ -76,7 +93,7 @@ export default function CommentItem({
                 </p>
                 <p
                   className="text-error-100 underline cursor-pointer"
-                  onClick={() => deleteComment.mutate(commentId)}
+                  onClick={() => setIsDeleteItemModalOpen(true)}
                 >
                   삭제
                 </p>
@@ -124,6 +141,25 @@ export default function CommentItem({
             </Link>
           ) : (
             <p className="mt-2 text-black-700 text-md">{content}</p>
+          )}
+
+          {isUserInfoModalOpen && (
+            <Modal onClose={() => setIsUserInfoModalOpen(false)}>
+              <UserInfoModal
+                image={image}
+                nickname={nickname}
+                onClose={() => setIsUserInfoModalOpen(false)}
+              />
+            </Modal>
+          )}
+
+          {isDeleteItemModalOpen && (
+            <Modal onClose={() => setIsDeleteItemModalOpen(false)}>
+              <DeleteItemModal
+                onCancel={() => setIsDeleteItemModalOpen(false)}
+                onDelete={handleDeleteCommentItem}
+              />
+            </Modal>
           )}
         </div>
       </div>

--- a/src/components/DeleteItemModal.tsx
+++ b/src/components/DeleteItemModal.tsx
@@ -1,0 +1,52 @@
+import Image from "next/image";
+import warn from "@/assets/icons/warn.svg";
+import Button from "./Button";
+
+export default function DeleteItemModal({
+  onCancel,
+  onDelete,
+  isComment = true,
+}: {
+  onCancel: () => void;
+  onDelete: () => void;
+  isComment?: boolean;
+}) {
+  return (
+    <div className="w-[280px] lg:w-[312px] flex flex-col items-center">
+      <Image
+        src={warn}
+        width={44}
+        height={44}
+        alt="경고 아이콘"
+        className="mb-4"
+      />
+      <h2 className="text-black-700 font-semibold text-md lg:text-lg">
+        {isComment ? "댓글을 삭제하시겠어요?" : "에피그램을 삭제하시겠어요?"}
+      </h2>
+      <p className="text-gray-400 text-sm lg:text-md">
+        {isComment
+          ? "댓글은 삭제 후, 복구할 수 없어요."
+          : "에피그램은 삭제 후, 복구할 수 없어요."}
+      </p>
+
+      <div className="flex justify-between w-full mt-6">
+        <Button
+          variant="tertiary"
+          size="md"
+          className="w-[48%]"
+          onClick={onCancel}
+        >
+          취소
+        </Button>
+        <Button
+          variant="secondary"
+          size="md"
+          className="w-[48%]"
+          onClick={onDelete}
+        >
+          삭제하기
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/LoggedInHeader.tsx
+++ b/src/components/LoggedInHeader.tsx
@@ -54,7 +54,7 @@ export default function LoggedInHeader({
           </Link>
         </div>
         <Link href="/mypage" className="flex gap-2 items-center">
-          <ProfileImage src={image} size="small" clickable />
+          <ProfileImage src={image} size="sm" clickable />
           <p className="font-semibold text-md lg:text-lg text-black-600">
             {nickname}
           </p>

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,0 +1,53 @@
+"use client";
+import { useEffect, useRef } from "react";
+import { useClickOutside } from "@/lib/utils/useClickOutside";
+
+interface ModalProps {
+  children?: React.ReactNode;
+  className?: string;
+  onClose: () => void;
+}
+
+export default function Modal({
+  children,
+  className = "",
+  onClose,
+}: ModalProps) {
+  const modalRef = useRef<HTMLDivElement | null>(null);
+
+  useClickOutside(modalRef, onClose);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [onClose]);
+
+  useEffect(() => {
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = "auto";
+    };
+  }, []);
+
+  return (
+    <div
+      id="모달 외부"
+      role="dialog"
+      aria-modal="true"
+      className="pointer-events-auto fixed inset-0 z-100 flex h-full w-full items-center justify-center bg-gray-500/50"
+    >
+      <div
+        id="모달"
+        ref={modalRef}
+        className={`rounded-3xl bg-blue-100 p-6 shadow-lg ${className}`}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ProfileImage.tsx
+++ b/src/components/ProfileImage.tsx
@@ -9,9 +9,9 @@ const profileImageVariants = cva(
   {
     variants: {
       size: {
-        small: "w-[28px] h-[28px] lg:w-[36px] lg:h-[36px]",
-        medium: "w-[48px] h-[48px]",
-        large: "w-[80px] h-[80px] lg:w-[140px] lg:h-[140px]",
+        sm: "w-[28px] h-[28px] lg:w-[36px] lg:h-[36px]",
+        md: "w-[48px] h-[48px]",
+        lg: "w-[80px] h-[80px] lg:w-[140px] lg:h-[140px]",
       },
       clickable: {
         true: "cursor-pointer hover:brightness-90",
@@ -19,7 +19,7 @@ const profileImageVariants = cva(
       },
     },
     defaultVariants: {
-      size: "medium",
+      size: "md",
       clickable: false,
     },
   }

--- a/src/components/UserInfoModal.tsx
+++ b/src/components/UserInfoModal.tsx
@@ -1,0 +1,33 @@
+import Image from "next/image";
+import xGray from "@/assets/icons/x-gray.svg";
+import ProfileImage from "./ProfileImage";
+
+export default function UserInfoModal({
+  image,
+  nickname,
+  onClose,
+}: {
+  image: string | null;
+  nickname: string;
+  onClose: () => void;
+}) {
+  return (
+    <div className="w-[280px] lg:w-[312px]">
+      <div className="flex justify-end cursor-pointer">
+        <Image
+          src={xGray}
+          width={24}
+          height={24}
+          alt="모달 닫기 아이콘"
+          onClick={onClose}
+        />
+      </div>
+      <div className="flex flex-col items-center">
+        <ProfileImage src={image} size="md" className="mb-6" />
+        <p className="text-black-400 font-semibold text-md lg:text-lg">
+          {nickname}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/stories/ProfileImage.stories.tsx
+++ b/src/stories/ProfileImage.stories.tsx
@@ -7,7 +7,7 @@ const meta: Meta<typeof ProfileImage> = {
   tags: ["autodocs"],
   argTypes: {
     src: { control: "text" },
-    size: { control: "radio", options: ["small", "medium", "large"] },
+    size: { control: "radio", options: ["sm", "md", "lg"] },
     onClick: { action: "clicked" },
   },
 };
@@ -17,21 +17,21 @@ type Story = StoryObj<typeof ProfileImage>;
 
 export const Small: Story = {
   args: {
-    size: "small",
+    size: "sm",
     clickable: false,
   },
 };
 
 export const Medium: Story = {
   args: {
-    size: "medium",
+    size: "md",
     clickable: false,
   },
 };
 
 export const Large: Story = {
   args: {
-    size: "large",
+    size: "lg",
     clickable: true,
   },
 };


### PR DESCRIPTION
## :hash: Issue

<!-- 이슈 번호를 작성해 주세요. -->
- close #35 
## :memo: Description

<!-- PR 내용을 불렛 형식으로 자세하게 작성해 주세요. -->
### 공통 컴포넌트 모달 컴포넌트 작업 내용입니다. ###
- 기본 Modal 컴포넌트로 백그라운드와 패딩, 배경색 설정되어 있음
- esc 키 누르면 모달창 닫히도록 설정
- 모달 열렸을 때 백그라운드 스크롤 불가
- useClickOutside 유틸 함수를 불러와 외부 클릭 시 모달 창 닫히도록 설정
- UserInfoModal 컴포넌트를 만들어 댓글 컴포넌트의 유저 프로필 이미지 클릭 시 열리도록 설정하였음
  - X 이미지 클릭하면 모달 창 닫힘 
- DeleteItem 컴포넌트를 만들어 댓글 컴포넌트의 삭제 텍스트 클릭 시 열리도록 설정함
  - "삭제하기" 클릭하면 즉시 삭제됨
  - "취소" 클릭하면 모달 창 닫힘
  - 에피그램 삭제 모달에도 해당 모달 컴포넌트 사용할 예정
- 반응형 구현 

![스크린샷 2025-05-05 130402](https://github.com/user-attachments/assets/1c9fdd23-6bf9-4cb8-8563-97291a9a91d6)
![스크린샷 2025-05-05 130417](https://github.com/user-attachments/assets/af4bbd1a-6c76-42d8-a7b4-7cb0e30d9b12)

## :white_check_mark: Checklist

### PR Checklist

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] Assignee 및 Reviewer, 적절한 Label 지정
- [x] Development 설정

### Additional Notes

<!-- 추가 사항이 있을 경우, 작성해 주세요. -->

- 공통 컴포넌트 Button의 텍스트 크기 줄임
- 공통 컴포넌트 ProfileImage의 size명을 small -> sm 형식으로 바꾸어 전체 파일에서 수정함
