### PR TITLE
feat/41/에피그램상세페이지 댓글

### DIFF
--- a/src/app/(with-header)/epigrams/[id]/_components/EpigramComments.tsx
+++ b/src/app/(with-header)/epigrams/[id]/_components/EpigramComments.tsx
@@ -1,0 +1,159 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useCreateComment } from "@/lib/hooks/useComments";
+import { useEpigramCommentList } from "@/lib/hooks/useEpigrams";
+import { useMyData } from "@/lib/hooks/useUsers";
+import { UpdateCommentResponse } from "@/lib/types/comments";
+import Button from "@/components/Button";
+import ProfileImage from "@/components/ProfileImage";
+import Empty from "@/components/Empty";
+import CommentItem from "@/components/CommentItem";
+import Image from "next/image";
+import plus from "@/assets/icons/plus.svg";
+
+export default function EpigramComments({ id }: { id: number }) {
+  const [limit, setLimit] = useState(3);
+  const [addContent, setAddContent] = useState("");
+  const { data, isLoading, isError } = useEpigramCommentList(id, {
+    limit: limit,
+  });
+  const { data: user } = useMyData();
+  const [isPrivate, setIsPrivate] = useState(false);
+  const [commentList, setCommentList] = useState(data?.list || []);
+  const createComment = useCreateComment();
+
+  useEffect(() => {
+    if (data?.list) setCommentList(data.list);
+  }, [data]);
+
+  const handleLoadMore = (e: React.MouseEvent) => {
+    e.preventDefault();
+
+    if ((commentList.length ?? 0) < (data?.totalCount ?? Infinity))
+      setLimit((prev) => prev + 3);
+  };
+
+  const handleCreateComment = () => {
+    createComment.mutate(
+      {
+        epigramId: id,
+        content: addContent.trim(),
+        isPrivate,
+      },
+      {
+        onSuccess: (newComment) => {
+          setCommentList((prev) => [newComment, ...prev]);
+          setAddContent("");
+        },
+      }
+    );
+  };
+
+  const handleUpdateComment = (updatedComment: UpdateCommentResponse) => {
+    setCommentList((prevList) =>
+      prevList.map((comment) =>
+        comment.id === updatedComment.id ? updatedComment : comment
+      )
+    );
+  };
+
+  const handleDeleteComment = (id: number) => {
+    setCommentList((prevList) =>
+      prevList.filter((comment) => comment.id !== id)
+    );
+  };
+
+  if (isLoading) return <p>로딩 중...</p>;
+  if (isError) return <p>에러가 발생했습니다.</p>;
+
+  return (
+    <div className="mt-12 max-w-[640px] mx-auto mb-40 px-6 md:px-0">
+      <h2 className="font-semibold text-black-600 text-lg lg:text-2lg mb-4">
+        댓글 ({data?.totalCount})
+      </h2>
+      <div className="flex gap-6">
+        {user && (
+          <ProfileImage
+            size="md"
+            src={user.image}
+            className="w-[48px] h-[48px] aspect-square"
+          />
+        )}
+        <div className="w-full">
+          <textarea
+            value={addContent}
+            onChange={(e) => setAddContent(e.target.value)}
+            className="w-full border rounded-md p-2 text-black-700 border-line-200 text-sm outline-black-600"
+            placeholder="100자 이내로 입력하세요."
+            rows={3}
+          />
+          <div className="flex justify-between mt-2 mb-4">
+            <div className="flex items-center gap-2">
+              <p className="font-semibold text-xs lg:text-md text-gray-400">
+                공개
+              </p>
+              <label
+                htmlFor="toggle"
+                className="relative inline-flex items-center cursor-pointer w-[32px] h-[16px]"
+              >
+                <input
+                  id="toggle"
+                  type="checkbox"
+                  checked={isPrivate}
+                  onChange={() => setIsPrivate((prev) => !prev)}
+                  className="sr-only peer"
+                />
+                <div className="w-full h-full peer-checked:bg-blue-300 bg-black-600 rounded-full transition-all" />
+                <span className="absolute left-4.5 top-1/2 -translate-y-1/2 w-[10px] h-[10px] bg-white rounded-full transition-transform peer-checked:-translate-x-3.5" />
+              </label>
+            </div>
+            <Button
+              size="sm"
+              onClick={handleCreateComment}
+              className="w-[52px] lg:w-[60px]"
+              disabled={addContent.trim() === "" || addContent.length > 100}
+            >
+              저장
+            </Button>
+          </div>
+        </div>
+      </div>
+      {commentList.length === 0 ? (
+        <Empty />
+      ) : (
+        <>
+          {commentList.map((comment) => (
+            <CommentItem
+              key={comment.id}
+              image={comment.writer.image}
+              commentId={comment.id}
+              nickname={comment.writer.nickname}
+              content={comment.content}
+              updatedAt={comment.updatedAt}
+              isMine={user?.id === comment.writer.id}
+              onUpdate={handleUpdateComment}
+              onDelete={handleDeleteComment}
+            />
+          ))}
+
+          {(commentList.length ?? 0) < (data?.totalCount ?? Infinity) && (
+            <Button
+              variant="outline"
+              size="xl"
+              isRoundedFull
+              className="mx-auto mt-14 w-[152px] lg:w-[240px]"
+              onClick={handleLoadMore}
+            >
+              <Image
+                src={plus}
+                alt="더보기 아이콘"
+                className="lg:mr-2 w-[20px] lg:w-[24px]"
+              />
+              최신 댓글 더보기
+            </Button>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/(with-header)/epigrams/[id]/_components/EpigramComments.tsx
+++ b/src/app/(with-header)/epigrams/[id]/_components/EpigramComments.tsx
@@ -20,10 +20,14 @@ export default function EpigramComments({ id }: { id: number }) {
   const { data: user } = useMyData();
   const [isPrivate, setIsPrivate] = useState(false);
   const [commentList, setCommentList] = useState(data?.list || []);
+  const [totalCount, setTotalCount] = useState(data?.totalCount || 0);
   const createComment = useCreateComment();
 
   useEffect(() => {
-    if (data?.list) setCommentList(data.list);
+    if (data?.list) {
+      setCommentList(data.list);
+      setTotalCount(data.totalCount);
+    }
   }, [data]);
 
   const handleLoadMore = (e: React.MouseEvent) => {
@@ -43,6 +47,7 @@ export default function EpigramComments({ id }: { id: number }) {
       {
         onSuccess: (newComment) => {
           setCommentList((prev) => [newComment, ...prev]);
+          setTotalCount((prev) => prev + 1);
           setAddContent("");
         },
       }
@@ -61,6 +66,7 @@ export default function EpigramComments({ id }: { id: number }) {
     setCommentList((prevList) =>
       prevList.filter((comment) => comment.id !== id)
     );
+    setTotalCount((prev) => Math.max(prev - 1, 0));
   };
 
   if (isLoading) return <p>로딩 중...</p>;
@@ -69,7 +75,7 @@ export default function EpigramComments({ id }: { id: number }) {
   return (
     <div className="mt-12 max-w-[640px] mx-auto mb-40 px-6 md:px-0">
       <h2 className="font-semibold text-black-600 text-lg lg:text-2lg mb-4">
-        댓글 ({data?.totalCount})
+        댓글 ({totalCount})
       </h2>
       <div className="flex gap-6">
         {user && (

--- a/src/app/(with-header)/epigrams/[id]/_components/EpigramDetail.tsx
+++ b/src/app/(with-header)/epigrams/[id]/_components/EpigramDetail.tsx
@@ -38,7 +38,7 @@ export default function EpigramDetail({ id }: { id: number }) {
     <>
       <section className="relative bg-blue-100 h-auto">
         <BackgroundLines />
-        <div className="relative w-full max-w-[640px] mx-auto max-[1250px]:px-4 min-[1251px]:px-0 py-10 z-50">
+        <div className="relative w-full max-w-[640px] mx-auto max-[1250px]:px-4 min-[1251px]:px-0 py-10 z-40">
           <div className="flex justify-between">
             <div>
               {epigramDetail?.tags.map((tag) => (

--- a/src/app/(with-header)/epigrams/[id]/page.tsx
+++ b/src/app/(with-header)/epigrams/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import EpigramDetail from "./_components/EpigramDetail";
+import EpigramComments from "./_components/EpigramComments";
 
 export default async function Page({
   params,
@@ -9,5 +10,10 @@ export default async function Page({
   const { id } = await params;
   if (isNaN(Number(id))) notFound();
 
-  return <EpigramDetail id={Number(id)} />;
+  return (
+    <>
+      <EpigramDetail id={Number(id)} />
+      <EpigramComments id={Number(id)} />
+    </>
+  );
 }

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -17,7 +17,7 @@ const buttonVariants = cva(
       },
       size: {
         sm: "h-[32px] lg:h-[44px] text-xs lg:text-lg px-3 rounded-[8px]",
-        md: "h-[42px] lg:h-[48px] text-md lg:text-2lg px-3 rounded-[12px]",
+        md: "h-[42px] lg:h-[48px] text-md lg:text-lg px-3 rounded-[12px]",
         lg: "h-[42px] lg:h-[56px] text-lg lg:text-2lg px-4 rounded-[16px]",
         xl: "h-[48px] lg:h-[64px] text-lg lg:text-2lg px-4 rounded-[16px]",
       },

--- a/src/components/Empty.tsx
+++ b/src/components/Empty.tsx
@@ -1,0 +1,62 @@
+import Image from "next/image";
+import empty from "@/assets/icons/empty.svg";
+import Button from "./Button";
+
+export default function Empty({
+  myEpigram,
+  myComment,
+}: {
+  myEpigram?: boolean;
+  myComment?: boolean;
+}) {
+  return (
+    <div className="flex flex-col gap-2 items-center justify-center mt-12">
+      <Image
+        src={empty}
+        className="w-[96px] h-[96px] lg:w-[144px] lg:h-[144px]"
+        alt="노 아이템"
+      />
+      {!myComment && !myEpigram && (
+        <p className="text-md lg:text-lg text-black-600 text-center">
+          아직 댓글이 없어요! <br />
+          댓글을 작성하고, 다른 사람들과 교류해 보세요.
+        </p>
+      )}
+
+      {myEpigram && (
+        <>
+          <p className="text-md text-black-600 text-center">
+            아직 작성한 에피그램이 없어요! <br />
+            에피그램을 작성하고, 감정을 공유해 보세요.
+          </p>
+          <Button
+            variant="outline"
+            size="xl"
+            isRoundedFull
+            className="mt-4 w-[152px] lg:w-[240px]"
+            href="/addepigram"
+          >
+            에피그램 만들기
+          </Button>
+        </>
+      )}
+      {myComment && (
+        <>
+          <p className="text-md text-black-600 text-center">
+            아직 작성한 댓글이 없어요! <br />
+            댓글을 작성하고, 다른 사람들과 교류해 보세요.
+          </p>
+          <Button
+            variant="outline"
+            size="xl"
+            isRoundedFull
+            className="mt-4 w-[152px] lg:w-[240px]"
+            href="/feeds"
+          >
+            에피그램 둘러보기
+          </Button>
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## :hash: Issue

<!-- 이슈 번호를 작성해 주세요. -->
- close #41 
## :memo: Description

<!-- PR 내용을 불렛 형식으로 자세하게 작성해 주세요. -->
### 에피그램 상세 페이지의 댓글 컴포넌트 작업 내용입니다. ###
- 맨 처음 댓글 3개 불러오며 "댓글 더보기" 버튼 클릭 시 3개씩 추가로 불러옴
- 에피그램 작성자만 다른 유저가 남긴 비공개 댓글을 작성한 그대로 볼 수 있음
- 내가 남긴 비공개 댓글도 작성한 그대로 볼 수 있으며 다른 유저가 남긴 비공개 댓글은 아예 볼 수 없고, 댓글 수에도 반영되지 않음
- 로그인해야 접근할 수 있는 페이지로 로그인한 유저 ID와 댓글 작성자 ID를 비교하여 일치했을 때 댓글 수정/삭제 가능
- 댓글 작성 시, 댓글 목록에 바로 표시되고 댓글 수도 +1
  - 공개 여부 토글 설정 가능
  - 100자 이내 제한 placeholder 설정과 버튼 disabled 설정 
- 댓글 삭제 시, 댓글 목록에 바로 지워지고 댓글 수도 -1
- 댓글이 0개일 때 렌더링하는 Empty 컴포넌트 제작(마이 페이지에서도 사용 가능)
- 추후 비공개 댓글에 따로 표시할 뱃지 같은 요소 만들어서 에피그램 작성자에게도 비공개 댓글임을 명시적으로 알릴 만한 UI가 있으면 좋을 듯

![스크린샷 2025-05-14 100500](https://github.com/user-attachments/assets/ce87ccb1-07c2-43dd-836c-b8dda6d671f2)
![스크린샷 2025-05-14 100544](https://github.com/user-attachments/assets/87d7bc58-b493-4d61-9b5a-d42d97df349f)

## :white_check_mark: Checklist

### PR Checklist

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] Assignee 및 Reviewer, 적절한 Label 지정
- [x] Development 설정

### Additional Notes

<!-- 추가 사항이 있을 경우, 작성해 주세요. -->

- 공통 컴포넌트 Button 폰트 크기 설정
- 에피그램 상세 컴포넌트 z-index 설정 수정(헤더를 겹치는 버그 해결)
