### PR TITLE
feat/47/에피그램작성페이지 에피그램작성

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.56.1",
         "react-simple-typewriter": "^5.0.1",
+        "react-toastify": "^11.0.5",
         "tailwind-variants": "^1.0.0",
         "zod": "^3.24.3"
       },
@@ -11426,6 +11427,18 @@
       "peerDependencies": {
         "react": ">=18.0.0",
         "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
+      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/readable-stream": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.56.1",
     "react-simple-typewriter": "^5.0.1",
+    "react-toastify": "^11.0.5",
     "tailwind-variants": "^1.0.0",
     "zod": "^3.24.3"
   },

--- a/src/app/(with-header)/addepigram/_components/CreateEpigramForm.tsx
+++ b/src/app/(with-header)/addepigram/_components/CreateEpigramForm.tsx
@@ -1,0 +1,194 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useCreateEpigram } from "@/lib/hooks/useEpigrams";
+import {
+  CreateEpigramRequest,
+  createEpigramRequestSchema,
+} from "@/lib/types/epigrams";
+import { toast } from "react-toastify";
+import Input from "@/components/Input";
+import Button from "@/components/Button";
+import Image from "next/image";
+import xGray from "@/assets/icons/x-gray.svg";
+
+export default function CreateEpigramForm() {
+  const { mutate } = useCreateEpigram();
+  const router = useRouter();
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    setValue,
+    watch,
+    formState: { errors },
+  } = useForm<CreateEpigramRequest>({
+    resolver: zodResolver(createEpigramRequestSchema),
+    mode: "onChange",
+    defaultValues: {
+      referenceTitle: "",
+      referenceUrl: "",
+      tags: [],
+    },
+  });
+
+  const tags = watch("tags");
+  const [tagInput, setTagInput] = useState("");
+  const [tagInputError, setTagInputError] = useState("");
+
+  const updateTags = (newTags: string[]) => {
+    setValue("tags", newTags, { shouldValidate: true });
+  };
+
+  const onSubmit = (data: CreateEpigramRequest) => {
+    data.referenceTitle = data.referenceTitle || undefined;
+    data.referenceUrl = data.referenceUrl || undefined;
+
+    mutate(data, {
+      onSuccess: () => {
+        toast.success("에피그램이 성공적으로 등록되었습니다!");
+        reset();
+        router.push("/epigrams");
+      },
+      onError: () => {
+        toast.error("등록에 실패했습니다.");
+      },
+    });
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      const newTag = e.currentTarget.value.trim();
+
+      if (!newTag) {
+        setTagInputError("태그를 입력해 주세요.");
+        return;
+      }
+
+      if (tags.includes(newTag)) {
+        setTagInputError("중복된 태그입니다.");
+        return;
+      }
+
+      if (newTag.length > 10) {
+        setTagInputError("10자 이내로 입력해 주세요.");
+        return;
+      }
+
+      if (tags.length >= 3) {
+        setTagInputError("최대 3개까지 입력할 수 있습니다.");
+        return;
+      }
+
+      updateTags([...tags, newTag]);
+      setTagInput("");
+      setTagInputError("");
+    }
+  };
+
+  return (
+    <form
+      className="space-y-[40px]"
+      onSubmit={(e) => {
+        e.preventDefault();
+        handleSubmit(onSubmit)();
+      }}
+    >
+      <h2 className="text-black-600 font-semibold text-lg lg:text-xl mb-6 lg:mb-10">
+        에피그램 만들기
+      </h2>
+
+      <div>
+        <label className="text-blue-900 flex items-center gap-1 text-md lg:text-2lg font-medium mb-4">
+          내용
+          <span className="pt-1.5 text-lg font-medium text-red-500">*</span>
+        </label>
+        <textarea
+          {...register("content")}
+          placeholder="500자 이내로 입력해 주세요."
+          rows={5}
+          className={`bg-blue-100 placeholder:text-blue-400 px-4 py-[10px] w-full text-md lg:text-lg rounded-xl border focus:outline-2 ${
+            errors.content
+              ? "border-error-100 focus:outline-error-100"
+              : "border-blue-300 hover:border-blue-500 focus:outline-blue-500"
+          }`}
+        />
+        {errors.content && (
+          <p className="text-error-100 text-sm lg:text-md">
+            {errors.content.message}
+          </p>
+        )}
+      </div>
+
+      <Input
+        label="저자"
+        required
+        whiteBg
+        placeholder="저자 이름 입력"
+        {...register("author")}
+        error={errors.author?.message}
+      />
+
+      <div>
+        <Input
+          label="출처"
+          whiteBg
+          placeholder="출처 제목 입력"
+          {...register("referenceTitle")}
+        />
+        <Input
+          whiteBg
+          placeholder="URL (ex. https://www.website.com)"
+          {...register("referenceUrl")}
+        />
+      </div>
+
+      <div>
+        <label className="text-blue-900 flex items-center gap-1 text-md lg:text-2lg font-medium">
+          태그
+          <span className="pt-1.5 text-lg font-medium text-red-500">*</span>
+        </label>
+        <Input
+          whiteBg
+          placeholder="입력하여 태그 작성 (최대 10자)"
+          onKeyDown={handleKeyDown}
+          onChange={(e) => {
+            setTagInput(e.target.value);
+            setTagInputError("");
+          }}
+          value={tagInput}
+          error={tagInputError || errors.tags?.message}
+        />
+
+        <div className="flex flex-wrap gap-2">
+          {tags.map((tag, index) => (
+            <div key={index} className="flex gap-2 items-center mt-4">
+              <span className="text-md lg:text-lg bg-blue-200 rounded-xl px-2 py-1 text-black-300">
+                {tag}
+                <button
+                  onClick={() => updateTags(tags.filter((_, i) => i !== index))}
+                >
+                  <Image
+                    src={xGray}
+                    alt="태그 삭제 아이콘"
+                    width={14}
+                    height={14}
+                    className="inline-block ml-1 cursor-pointer pb-0.5"
+                  />
+                </button>
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <Button type="submit" size="xl" className="w-full mt-16 mb-8 lg:mb-30">
+        작성 완료
+      </Button>
+    </form>
+  );
+}

--- a/src/app/(with-header)/addepigram/_components/CreateEpigramForm.tsx
+++ b/src/app/(with-header)/addepigram/_components/CreateEpigramForm.tsx
@@ -24,7 +24,7 @@ export default function CreateEpigramForm() {
     reset,
     setValue,
     watch,
-    formState: { errors },
+    formState: { errors, isValid },
   } = useForm<CreateEpigramRequest>({
     resolver: zodResolver(createEpigramRequestSchema),
     mode: "onChange",
@@ -186,7 +186,12 @@ export default function CreateEpigramForm() {
         </div>
       </div>
 
-      <Button type="submit" size="xl" className="w-full mt-16 mb-8 lg:mb-30">
+      <Button
+        type="submit"
+        size="xl"
+        disabled={!isValid}
+        className="w-full mt-16 mb-8 lg:mb-30"
+      >
         작성 완료
       </Button>
     </form>

--- a/src/app/(with-header)/addepigram/page.tsx
+++ b/src/app/(with-header)/addepigram/page.tsx
@@ -1,3 +1,9 @@
+import CreateEpigramForm from "./_components/CreateEpigramForm";
+
 export default function Page() {
-  return <div>에피그램 작성 페이지</div>;
+  return (
+    <div className="max-w-[640px] mx-auto mt-12 lg:mt-20 px-6 md:px-0 mb-20">
+      <CreateEpigramForm />
+    </div>
+  );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { IropkeBatang, Pretendard } from "@/font";
+import { ToastContainer, Slide } from "react-toastify";
 import QueryClientProvider from "@/lib/network/QuerycClientProvider";
 import "./globals.css";
 
@@ -19,6 +20,28 @@ export default function RootLayout({
     >
       <body className="bg-background-100">
         <QueryClientProvider>{children}</QueryClientProvider>
+        <ToastContainer
+          position="bottom-center"
+          toastStyle={{
+            minHeight: "unset",
+            minWidth: "unset",
+            maxWidth: "80vw",
+            marginBottom: "30px",
+            backgroundColor: "#454545",
+            color: "#ffffff",
+            borderRadius: "16px",
+          }}
+          toastClassName="w-fit flex justify-center text-sm md:text-md"
+          autoClose={2000}
+          icon={false}
+          closeButton={false}
+          hideProgressBar
+          draggable
+          closeOnClick
+          newestOnTop
+          transition={Slide}
+          limit={3}
+        />
       </body>
     </html>
   );

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -25,14 +25,14 @@ export function Label({
   return (
     <label
       className={cn(
-        "text-blue-900 flex items-center gap-1 text-lg lg:text-xl font-medium",
+        "text-blue-900 flex items-center gap-1 text-md lg:text-2lg font-medium",
         className
       )}
       {...props}
     >
       {children}
       {required && (
-        <span className="pt-1.5 text-lg font-medium text-red-500">*</span>
+        <span className="pt-1.5 text-lg font-medium text-error-100">*</span>
       )}
     </label>
   );
@@ -40,7 +40,7 @@ export function Label({
 
 export function Error({ children }: PropsWithChildren) {
   return (
-    <span className="block mt-2 lg:text-md text-sm text-red-500">
+    <span className="block mt-2 lg:text-md text-sm text-error-100">
       {children}
     </span>
   );
@@ -72,7 +72,7 @@ export default function Input({
       <input
         id={id}
         className={cn(
-          "h-[44px] lg:h-[64px] rounded-xl text-black-950 mt-4 w-full placeholder:text-blue-400 text-lg lg:text-xl bg-blue-200 border p-3 focus:outline-2",
+          "h-[44px] lg:h-[60px] rounded-xl text-black-950 mt-4 w-full placeholder:text-blue-400 text-md lg:text-lg bg-blue-200 border p-3 focus:outline-2",
           whiteBg ? "bg-white" : undefined,
           error
             ? "border-error-100 focus:outline-error-100"

--- a/src/lib/types/epigrams.ts
+++ b/src/lib/types/epigrams.ts
@@ -59,18 +59,15 @@ export type EpigramDetailResponse = z.infer<typeof epigramDetailResponseSchema>;
 // 에피그램 작성 요청 API 타입
 export const createEpigramRequestSchema = z.object({
   tags: z
-    .array(
-      z.object({
-        name: z.string().min(1).max(10),
-      })
-    )
+    .array(z.string().min(1).max(10))
+    .min(1, { message: "최소 1개의 태그를 입력해 주세요." })
     .max(3),
-  referenceUrl: z.string().url().optional(),
+  referenceUrl: z.string().url().or(z.literal("")).optional(),
   referenceTitle: z.string().max(100).optional(),
   author: z.string().min(1, { message: "저자를 입력해 주세요." }).max(30),
   content: z
     .string()
-    .min(1)
+    .min(1, { message: "내용을 입력해 주세요." })
     .max(500, { message: "500자 이내로 입력해 주세요." }),
 });
 


### PR DESCRIPTION
## :hash: Issue

<!-- 이슈 번호를 작성해 주세요. -->
- close #47 
## :memo: Description

<!-- PR 내용을 불렛 형식으로 자세하게 작성해 주세요. -->

⚠️ react-toastify 라이브러리를 설치했습니다.
- RootLayout에 ToastContainer 컴포넌트 설정
- 토스트 2초 설정
- 닫기 버튼, 아이콘, 진행 바 미표시
- 새 토스트가 생길 경우 위에 쌓임
- 토스트를 드래그 또는 클릭 시 닫힘
- 토스트 나타날 때 애니메이션 Slide 효과
- 토스트는 동시에 최대 3개까지 표시됨

### 에피그램 작성 페이지의 에피그램 작성 컴포넌트 작업 내용입니다. ###
-  내용, 저자, 태그 필수 입력, 출처 제목/url은 선택 입력
- 에피그램 작성 타입 에러 메시지 연결
- 내용 미입력 또는 500자 이상 입력 시 에러 메시지 표시
- 저자 미입력 시 에러 메시지 표시
- 태그 미입력 시 에러 메시지 표시
  - 10자 이상 작성, 중복 태그 작성, 3개 이상 작성 시 에러 메시지 표시
- 에피그램 작성 등록 성공/실패 시 토스트 알림 처리

https://github.com/user-attachments/assets/c2532eff-7608-447c-abf0-2fb5129a6821


## :white_check_mark: Checklist

### PR Checklist

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] Assignee 및 Reviewer, 적절한 Label 지정
- [x] Development 설정

### Additional Notes

<!-- 추가 사항이 있을 경우, 작성해 주세요. -->

- 폼 유효성 검사하여 제출 버튼 비활성화 로직 추가
