### PR TITLE
feat/49/에피그램수정페이지 에피그램수정

### DIFF
--- a/src/app/(with-header)/addepigram/_components/CreateEpigramForm.tsx
+++ b/src/app/(with-header)/addepigram/_components/CreateEpigramForm.tsx
@@ -48,10 +48,10 @@ export default function CreateEpigramForm() {
     data.referenceUrl = data.referenceUrl || undefined;
 
     mutate(data, {
-      onSuccess: () => {
+      onSuccess: (createdEpigram) => {
         toast.success("에피그램이 성공적으로 등록되었습니다!");
         reset();
-        router.push("/epigrams");
+        router.push(`/epigrams/${createdEpigram.id}`);
       },
       onError: () => {
         toast.error("등록에 실패했습니다.");
@@ -169,17 +169,15 @@ export default function CreateEpigramForm() {
             <div key={index} className="flex gap-2 items-center mt-4">
               <span className="text-md lg:text-lg bg-blue-200 rounded-xl px-2 py-1 text-black-300">
                 {tag}
-                <button
+
+                <Image
+                  src={xGray}
+                  alt="태그 삭제 아이콘"
+                  width={14}
+                  height={14}
+                  className="inline-block ml-1 cursor-pointer pb-0.5"
                   onClick={() => updateTags(tags.filter((_, i) => i !== index))}
-                >
-                  <Image
-                    src={xGray}
-                    alt="태그 삭제 아이콘"
-                    width={14}
-                    height={14}
-                    className="inline-block ml-1 cursor-pointer pb-0.5"
-                  />
-                </button>
+                />
               </span>
             </div>
           ))}

--- a/src/app/(with-header)/epigrams/[id]/edit/_components/EditEpigramForm.tsx
+++ b/src/app/(with-header)/epigrams/[id]/edit/_components/EditEpigramForm.tsx
@@ -1,0 +1,216 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useEpigramDetail, useUpdateEpigram } from "@/lib/hooks/useEpigrams";
+import {
+  UpdateEpigramRequest,
+  updateEpigramRequestSchema,
+} from "@/lib/types/epigrams";
+import { toast } from "react-toastify";
+import Input from "@/components/Input";
+import Button from "@/components/Button";
+import Image from "next/image";
+import xGray from "@/assets/icons/x-gray.svg";
+
+export default function EditEpigramForm() {
+  const params = useParams();
+  const router = useRouter();
+  const id = Number(params.id);
+  const { data: epigramData, isLoading } = useEpigramDetail(id);
+  const { mutate } = useUpdateEpigram(id);
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    setValue,
+    watch,
+    formState: { errors, isValid },
+  } = useForm<UpdateEpigramRequest>({
+    resolver: zodResolver(updateEpigramRequestSchema),
+    mode: "onChange",
+    defaultValues: {
+      content: "",
+      author: "",
+      referenceTitle: "",
+      referenceUrl: "",
+      tags: [],
+    },
+  });
+
+  useEffect(() => {
+    if (epigramData) {
+      reset({
+        content: epigramData.content,
+        author: epigramData.author,
+        referenceTitle: epigramData.referenceTitle || "",
+        referenceUrl: epigramData.referenceUrl || "",
+        tags: epigramData.tags?.map((tag) => tag.name) || [],
+      });
+    }
+  }, [epigramData, reset]);
+
+  const tags = watch("tags");
+  const [tagInput, setTagInput] = useState("");
+  const [tagInputError, setTagInputError] = useState("");
+
+  const updateTags = (newTags: string[]) => {
+    setValue("tags", newTags, { shouldValidate: true });
+  };
+
+  const onSubmit = (data: UpdateEpigramRequest) => {
+    data.referenceTitle = data.referenceTitle || undefined;
+    data.referenceUrl = data.referenceUrl || undefined;
+
+    mutate(data, {
+      onSuccess: (updatedEpigram) => {
+        toast.success("에피그램이 수정되었습니다!");
+        router.push(`/epigrams/${updatedEpigram.id}`);
+      },
+      onError: (error) => {
+        toast.error("수정에 실패했습니다.");
+        console.error(error);
+      },
+    });
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      const newTag = e.currentTarget.value.trim();
+
+      if (!newTag) {
+        setTagInputError("태그를 입력해 주세요.");
+        return;
+      }
+
+      if (tags.includes(newTag)) {
+        setTagInputError("중복된 태그입니다.");
+        return;
+      }
+
+      if (newTag.length > 10) {
+        setTagInputError("10자 이내로 입력해 주세요.");
+        return;
+      }
+
+      if (tags.length >= 3) {
+        setTagInputError("최대 3개까지 입력할 수 있습니다.");
+        return;
+      }
+
+      updateTags([...tags, newTag]);
+      setTagInput("");
+      setTagInputError("");
+    }
+  };
+
+  if (isLoading) return <div>로딩 중</div>;
+
+  return (
+    <form
+      className="space-y-[40px]"
+      onSubmit={(e) => {
+        e.preventDefault();
+        handleSubmit(onSubmit)();
+      }}
+    >
+      <h2 className="text-black-600 font-semibold text-lg lg:text-xl mb-6 lg:mb-10">
+        에피그램 수정
+      </h2>
+
+      <div>
+        <label className="text-blue-900 flex items-center gap-1 text-md lg:text-2lg font-medium mb-4">
+          내용
+          <span className="pt-1.5 text-lg font-medium text-red-500">*</span>
+        </label>
+        <textarea
+          {...register("content")}
+          placeholder="500자 이내로 입력해 주세요."
+          rows={5}
+          className={`bg-blue-100 placeholder:text-blue-400 px-4 py-[10px] w-full text-md lg:text-lg rounded-xl border focus:outline-2 ${
+            errors.content
+              ? "border-error-100 focus:outline-error-100"
+              : "border-blue-300 hover:border-blue-500 focus:outline-blue-500"
+          }`}
+        />
+        {errors.content && (
+          <p className="text-error-100 text-sm lg:text-md">
+            {errors.content.message}
+          </p>
+        )}
+      </div>
+
+      <Input
+        label="저자"
+        required
+        whiteBg
+        placeholder="저자 이름 입력"
+        {...register("author")}
+        error={errors.author?.message}
+      />
+
+      <div>
+        <Input
+          label="출처"
+          whiteBg
+          placeholder="출처 제목 입력"
+          {...register("referenceTitle")}
+        />
+        <Input
+          whiteBg
+          placeholder="URL (ex. https://www.website.com)"
+          {...register("referenceUrl")}
+        />
+      </div>
+
+      <div>
+        <label className="text-blue-900 flex items-center gap-1 text-md lg:text-2lg font-medium">
+          태그
+          <span className="pt-1.5 text-lg font-medium text-red-500">*</span>
+        </label>
+        <Input
+          whiteBg
+          placeholder="입력하여 태그 작성 (최대 10자)"
+          onKeyDown={handleKeyDown}
+          onChange={(e) => {
+            setTagInput(e.target.value);
+            setTagInputError("");
+          }}
+          value={tagInput}
+          error={tagInputError || errors.tags?.message}
+        />
+
+        <div className="flex flex-wrap gap-2">
+          {tags.map((tag, index) => (
+            <div key={index} className="flex gap-2 items-center mt-4">
+              <span className="text-md lg:text-lg bg-blue-200 rounded-xl px-2 py-1 text-black-300">
+                {tag}
+
+                <Image
+                  src={xGray}
+                  alt="태그 삭제 아이콘"
+                  width={14}
+                  height={14}
+                  className="inline-block ml-1 cursor-pointer pb-0.5"
+                  onClick={() => updateTags(tags.filter((_, i) => i !== index))}
+                />
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <Button
+        type="submit"
+        size="xl"
+        disabled={!isValid}
+        className="w-full mt-16 mb-8 lg:mb-30"
+      >
+        수정 완료
+      </Button>
+    </form>
+  );
+}

--- a/src/app/(with-header)/epigrams/[id]/edit/page.tsx
+++ b/src/app/(with-header)/epigrams/[id]/edit/page.tsx
@@ -1,3 +1,9 @@
+import EditEpigramForm from "./_components/EditEpigramForm";
+
 export default function Page() {
-  return <div>에피그램 수정 페이지</div>;
+  return (
+    <div className="max-w-[640px] mx-auto mt-12 lg:mt-20 px-6 md:px-0 mb-20">
+      <EditEpigramForm />
+    </div>
+  );
 }

--- a/src/lib/hooks/useEpigrams.ts
+++ b/src/lib/hooks/useEpigrams.ts
@@ -43,7 +43,7 @@ export const useEpigramToday = () => {
 // 에피그램 상세 조회 훅
 export const useEpigramDetail = (id: number) => {
   return useQuery<EpigramDetailResponse>({
-    queryKey: ["epigramDetail", id],
+    queryKey: ["epigrams", id],
     queryFn: () => getEpigramDetail(id!),
   });
 };
@@ -64,8 +64,8 @@ export const useUpdateEpigram = (id: number) => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (data: UpdateEpigramRequest) => updateEpigram(id, data),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["epigrams"] });
+    onSuccess: (updatedEpigram) => {
+      queryClient.setQueryData(["epigrams", id], updatedEpigram);
     },
   });
 };

--- a/src/lib/types/epigrams.ts
+++ b/src/lib/types/epigrams.ts
@@ -81,18 +81,15 @@ export type CreateEpigramResponse = z.infer<typeof createEpigramResponseSchema>;
 // 에피그램 수정 요청 API 타입
 export const updateEpigramRequestSchema = z.object({
   tags: z
-    .array(
-      z.object({
-        name: z.string().min(1).max(10),
-      })
-    )
+    .array(z.string().min(1).max(10))
+    .min(1, { message: "최소 1개의 태그를 입력해 주세요." })
     .max(3),
-  referenceUrl: z.string().url().optional(),
+  referenceUrl: z.string().url().or(z.literal("")).optional(),
   referenceTitle: z.string().max(100).optional(),
   author: z.string().min(1, { message: "저자를 입력해 주세요." }).max(30),
   content: z
     .string()
-    .min(1)
+    .min(1, { message: "내용을 입력해 주세요." })
     .max(500, { message: "500자 이내로 입력해 주세요." }),
 });
 


### PR DESCRIPTION
## :hash: Issue

<!-- 이슈 번호를 작성해 주세요. -->
- close #49 
## :memo: Description

<!-- PR 내용을 불렛 형식으로 자세하게 작성해 주세요. -->
### 에피그램 수정 페이지의 에피그램 수정 컴포넌트 작업 내용입니다. ###
- 내가 남긴 에피그램일 경우 표시되는 드롭다운에서 "수정하기" 클릭 시 이동하는 에피그램 수정 페이지
- 에피그램 작성 컴포넌트와 거의 흡사함(유효성 검사 등)
- 에피그램 상세 조회 훅을 불러와 기존에 작성한 값들 불러옴
- 만약 처음 에피그램 등록할 때 출처 제목/url을 작성했다면 수정할 때 제거할 수 없음(수정은 가능)
- 원래 출처를 작성 안 했다면 추가 가능
- 에피그램 상세 조회 훅과 에피그램 수정 훅 queryKey를 똑같이 맞추고, setQueryData로 캐시를 업데이트해서 수정 성공했을 때 이동하는 상세 페이지에서 새로고침 없이 바로 업데이트

https://github.com/user-attachments/assets/40f55b48-320e-4e1f-9d54-4187f595bdd6


## :white_check_mark: Checklist

### PR Checklist

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] Assignee 및 Reviewer, 적절한 Label 지정
- [x] Development 설정

### Additional Notes

<!-- 추가 사항이 있을 경우, 작성해 주세요. -->

- [x] (없음)
