### PR TITLE
feat/51/마이페이지 유저프로필

### DIFF
--- a/src/app/(with-header)/mypage/_components/EmotionChart.tsx
+++ b/src/app/(with-header)/mypage/_components/EmotionChart.tsx
@@ -1,0 +1,9 @@
+export default function Emotionchart() {
+  return (
+    <>
+      <h2 className="font-semibold text-black-600 text-lg lg:text-2lg">
+        감정 차트
+      </h2>
+    </>
+  );
+}

--- a/src/app/(with-header)/mypage/_components/MonthlyEmotion.tsx
+++ b/src/app/(with-header)/mypage/_components/MonthlyEmotion.tsx
@@ -1,0 +1,9 @@
+export default function MonthlyEmotion() {
+  return (
+    <>
+      <h2 className="font-semibold text-black-600 text-lg lg:text-2lg">
+        2025년 5월
+      </h2>
+    </>
+  );
+}

--- a/src/app/(with-header)/mypage/_components/MyItems.tsx
+++ b/src/app/(with-header)/mypage/_components/MyItems.tsx
@@ -1,0 +1,9 @@
+export default function MyItems() {
+  return (
+    <div className="max-w-[640px] w-full mx-auto px-6 md:px-0 mt-14">
+      <h2 className="font-semibold text-black-600 text-lg lg:text-2lg">
+        내 에피그램
+      </h2>
+    </div>
+  );
+}

--- a/src/app/(with-header)/mypage/_components/TodayEmotion.tsx
+++ b/src/app/(with-header)/mypage/_components/TodayEmotion.tsx
@@ -1,0 +1,9 @@
+export default function TodayEmotion() {
+  return (
+    <>
+      <h2 className="font-semibold text-black-600 text-lg lg:text-2lg">
+        오늘의 감정
+      </h2>
+    </>
+  );
+}

--- a/src/app/(with-header)/mypage/_components/UserContainer.tsx
+++ b/src/app/(with-header)/mypage/_components/UserContainer.tsx
@@ -1,0 +1,24 @@
+import TodayEmotion from "./TodayEmotion";
+import MonthlyEmotion from "./MonthlyEmotion";
+import Emotionchart from "./EmotionChart";
+import UserProfile from "./UserProfile";
+
+export default function UserContainer() {
+  return (
+    <div
+      className="relative bg-blue-100 w-full h-[1004px] rounded-3xl mt-16 lg:mt-32"
+      style={{
+        filter: "drop-shadow(0px 0px 36px rgba(0,0,0,0.05))",
+      }}
+    >
+      <div className="max-w-[640px] w-full mx-auto px-6 md:px-0">
+        <UserProfile />
+        <div className="pt-[180px] lg:pt-[275px] space-y-[60px] lg:space-y-[165px]">
+          <TodayEmotion />
+          <MonthlyEmotion />
+          <Emotionchart />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(with-header)/mypage/_components/UserProfile.tsx
+++ b/src/app/(with-header)/mypage/_components/UserProfile.tsx
@@ -1,0 +1,133 @@
+"use client";
+import { useActionState, useEffect, useState } from "react";
+import { useUserProfileContext } from "@/lib/contexts/UserProfileContext";
+import {
+  useMyData,
+  useProfileImage,
+  useUpdateMyData,
+} from "@/lib/hooks/useUsers";
+import { logout } from "@/lib/actions/logoutAction";
+import { toast } from "react-toastify";
+import Button from "@/components/Button";
+import ProfileImage from "@/components/ProfileImage";
+
+export default function UserProfile() {
+  const { data: user, isLoading, isError } = useMyData();
+  const [state, formAction] = useActionState(logout, null);
+  const { setProfileImageUrl, nickname, setNickname } = useUserProfileContext();
+  const { mutate: uploadImage } = useProfileImage();
+  const { mutate: patchUserData } = useUpdateMyData();
+  const [previewImage, setPreviewImage] = useState<string | null>(null);
+  const [isEditing, setIsEditing] = useState(false);
+
+  useEffect(() => {
+    if (user?.nickname) {
+      setNickname(user.nickname);
+    }
+  }, [user?.nickname, setNickname]);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const imageUrl = URL.createObjectURL(file);
+    setPreviewImage(imageUrl);
+
+    uploadImage(
+      { image: file },
+      {
+        onSuccess: (res) => {
+          setProfileImageUrl(res.url);
+          patchUserData({ image: res.url });
+          toast.success("프로필 이미지가 변경되었습니다.");
+        },
+        onError: () => {
+          toast.error("프로필 이미지 변경에 실패했습니다.");
+        },
+      }
+    );
+  };
+
+  const handleNicknameChange = () => {
+    patchUserData(
+      { nickname },
+      {
+        onSuccess: () => {
+          toast.success("닉네임이 변경되었습니다.");
+          setIsEditing(false);
+        },
+        onError: () => {
+          toast.error("닉네임 변경에 실패했습니다.");
+        },
+      }
+    );
+  };
+
+  useEffect(() => {
+    if (state?.status) {
+      toast.success("로그아웃 처리되었습니다.");
+      window.location.replace("/login");
+    }
+  }, [state]);
+
+  if (isLoading) return <div>로딩 중...</div>;
+  if (isError) return <div>에러가 발생했습니다.</div>;
+
+  return (
+    <div className="absolute top-0 left-1/2 -translate-x-1/2 translate-y-[-25%] flex flex-col items-center justify-center gap-4">
+      <label htmlFor="profile-upload">
+        <ProfileImage src={previewImage || user?.image} size="lg" clickable />
+      </label>
+      <input
+        id="profile-upload"
+        type="file"
+        accept="image/*"
+        onChange={handleFileChange}
+        className="hidden"
+      />
+
+      <div className="flex items-center gap-2">
+        {isEditing ? (
+          <>
+            <input
+              value={nickname}
+              onChange={(e) => setNickname(e.target.value)}
+              className="focus:outline-none focus:border-gray-800 text-black-700 border-0 border-b-1 border-gray-300 px-2 py-1 text-sm lg:text-lg"
+            />
+            <Button
+              size="sm"
+              onClick={handleNicknameChange}
+              className="w-[52px] lg:w-[60px]"
+              disabled={nickname.trim() === ""}
+            >
+              저장
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              className="w-[52px] lg:w-[60px]"
+              onClick={() => {
+                setNickname(user?.nickname || "");
+                setIsEditing(false);
+              }}
+            >
+              취소
+            </Button>
+          </>
+        ) : (
+          <>
+            <p
+              className="text-black-950 font-medium text-lg lg:text-2lg cursor-pointer hover:bg-line-100 px-2 py-1 rounded-xl"
+              onClick={() => setIsEditing(true)}
+            >
+              {user?.nickname}
+            </p>
+          </>
+        )}
+      </div>
+      <Button variant="reference" size="sm" isRoundedFull onClick={formAction}>
+        로그아웃
+      </Button>
+    </div>
+  );
+}

--- a/src/app/(with-header)/mypage/page.tsx
+++ b/src/app/(with-header)/mypage/page.tsx
@@ -1,3 +1,14 @@
+import UserContainer from "./_components/UserContainer";
+import MyItems from "./_components/MyItems";
+import { UserProfileProvider } from "@/lib/contexts/UserProfileContext";
+
 export default function Page() {
-  return <div>마이 페이지</div>;
+  return (
+    <UserProfileProvider>
+      <div className="h-full mb-40">
+        <UserContainer />
+        <MyItems />
+      </div>
+    </UserProfileProvider>
+  );
 }

--- a/src/components/ProfileImage.tsx
+++ b/src/components/ProfileImage.tsx
@@ -26,7 +26,7 @@ const profileImageVariants = cva(
 );
 
 interface ProfileImageProps extends VariantProps<typeof profileImageVariants> {
-  src: string | null;
+  src: string | null | undefined;
   className?: string;
   clickable?: boolean;
   onClick?: () => void;

--- a/src/lib/actions/logoutAction.ts
+++ b/src/lib/actions/logoutAction.ts
@@ -1,0 +1,19 @@
+"use server";
+import { cookies } from "next/headers";
+import { getErrorMessage } from "@/lib/network/errorMessage";
+
+export const logout = async () => {
+  try {
+    const cookieStore = await cookies();
+    cookieStore.delete("accessToken");
+    cookieStore.delete("refreshToken");
+
+    return {
+      status: true,
+      error: "",
+    };
+  } catch (error) {
+    console.error(error);
+    return { status: false, error: getErrorMessage(error) };
+  }
+};

--- a/src/lib/apis/users.ts
+++ b/src/lib/apis/users.ts
@@ -9,6 +9,9 @@ import {
   GetUserCommentListParams,
   UserCommentListResponse,
   userCommentListResponseSchema,
+  CreateProfileImageParams,
+  ProfileImageUrlResponse,
+  profileImageUrlResponseSchema,
 } from "../types/users";
 
 // 내 정보 조회 API
@@ -42,4 +45,18 @@ export const getUserCommentList = async (
     { params }
   );
   return safeResponse(response.data, userCommentListResponseSchema);
+};
+
+// 프로필 이미지 URL 생성 API
+export const postFileImageUrl = async (params: CreateProfileImageParams) => {
+  const response = await axiosClientHelper.post<ProfileImageUrlResponse>(
+    "/images/upload",
+    params,
+    {
+      headers: {
+        "Content-Type": "multipart/form-data",
+      },
+    }
+  );
+  return safeResponse(response.data, profileImageUrlResponseSchema);
 };

--- a/src/lib/contexts/UserProfileContext.tsx
+++ b/src/lib/contexts/UserProfileContext.tsx
@@ -1,0 +1,40 @@
+"use client";
+import { createContext, useContext, useState } from "react";
+
+type UserProfileContextType = {
+  profileImageUrl: string;
+  setProfileImageUrl: (url: string) => void;
+  nickname: string;
+  setNickname: (name: string) => void;
+};
+
+const UserProfileContext = createContext<UserProfileContextType | undefined>(
+  undefined
+);
+
+export const UserProfileProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const [profileImageUrl, setProfileImageUrl] = useState<string>("");
+  const [nickname, setNickname] = useState<string>("");
+
+  return (
+    <UserProfileContext.Provider
+      value={{ profileImageUrl, setProfileImageUrl, nickname, setNickname }}
+    >
+      {children}
+    </UserProfileContext.Provider>
+  );
+};
+
+export const useUserProfileContext = () => {
+  const context = useContext(UserProfileContext);
+  if (!context) {
+    throw new Error(
+      "useUserProfileContext must be used within a UserProfileProvider"
+    );
+  }
+  return context;
+};

--- a/src/lib/hooks/useUsers.ts
+++ b/src/lib/hooks/useUsers.ts
@@ -1,6 +1,8 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
+  CreateProfileImageParams,
   GetUserCommentListParams,
+  profileImageUrlSchema,
   UpdateUserRequest,
   UserCommentListResponse,
   UserResponse,
@@ -9,6 +11,7 @@ import {
   getMyData,
   getUserCommentList,
   getUserData,
+  postFileImageUrl,
   updateMyData,
 } from "../apis/users";
 
@@ -56,5 +59,17 @@ export const useUserCommentList = (
   return useQuery<UserCommentListResponse>({
     queryKey: ["users", id, params],
     queryFn: () => getUserCommentList(id!, params),
+  });
+};
+
+// 프로필 이미지 URL 생성 훅
+export const useProfileImage = () => {
+  return useMutation({
+    mutationFn: async (params: CreateProfileImageParams) => {
+      const { image } = params;
+      profileImageUrlSchema.parse(image);
+      const response = await postFileImageUrl(params);
+      return response;
+    },
   });
 };

--- a/src/lib/network/errorMessage.ts
+++ b/src/lib/network/errorMessage.ts
@@ -1,0 +1,21 @@
+import { isAxiosError } from "axios";
+
+interface ErrorResponse {
+  message: string;
+}
+
+export const getErrorMessage = (error: unknown): string => {
+  if (isAxiosError(error)) {
+    const response = error.response?.data as ErrorResponse | undefined;
+
+    if (response?.message) {
+      return response.message;
+    }
+
+    return error.message;
+  }
+
+  return error instanceof Error
+    ? error.message
+    : "알 수 없는 에러가 발생했어요.";
+};

--- a/src/lib/types/users.ts
+++ b/src/lib/types/users.ts
@@ -14,8 +14,8 @@ export type UserResponse = z.infer<typeof userResponseSchema>;
 
 // 내 정보 수정 요청 API 타입
 export const updateUserRequestSchema = z.object({
-  image: z.string().url().nullable(),
-  nickname: z.string().min(1).max(30),
+  image: z.string().url().nullable().optional(),
+  nickname: z.string().min(1).max(30).optional(),
 });
 
 export type UpdateUserRequest = z.infer<typeof updateUserRequestSchema>;
@@ -57,3 +57,40 @@ export const getUserCommentListParams = z.object({
 });
 
 export type GetUserCommentListParams = z.infer<typeof getUserCommentListParams>;
+
+// 프로필 이미지 URL 생성 API 타입
+export const profileImageUrlSchema = z
+  .instanceof(File)
+  .refine(
+    (file) =>
+      [
+        "image/jpg",
+        "image/jpeg",
+        "image/png",
+        "image/ico",
+        "image/gif",
+        "image/webp",
+      ].includes(file.type),
+    {
+      message: "지원되지 않는 이미지 파일입니다.",
+    }
+  )
+  .refine((file) => file.size < 5 * 1024 * 1024, {
+    message: "5MB 이하의 파일만 등록이 가능합니다.",
+  });
+
+export type ProfileImageUrl = z.infer<typeof profileImageUrlSchema>;
+
+// 프로필 이미지 URL 생성 요청 파라미터 API 타입
+export interface CreateProfileImageParams {
+  image: File;
+}
+
+// 프로필 이미지 URL 생성 응답 API 타입
+export const profileImageUrlResponseSchema = z.object({
+  url: z.string().url(),
+});
+
+export type ProfileImageUrlResponse = z.infer<
+  typeof profileImageUrlResponseSchema
+>;


### PR DESCRIPTION
## :hash: Issue

<!-- 이슈 번호를 작성해 주세요. -->
- close #51 
## :memo: Description

<!-- PR 내용을 불렛 형식으로 자세하게 작성해 주세요. -->
### 마이 페이지의 유저 프로필 컴포넌트 작업입니다. ###
**마이 페이지 레이아웃**
- UserContainer
  - UserProfile(유저 정보 조회 및 수정)
  - TodayEmotion(오늘의 감정)
  - MonthlyEmotion(이달의 감정)
  - EmotionChart(감정 차트)
- MyItems
  - 내 에피그램 및 내 댓글


**UserProfile 컴포넌트**
- 유저 프로필 이미지와 닉네임을 Context로 관리하고, Provider로 감싸서 마이 페이지 page.tsx에서 상태 공유함
- 유저 정보 수정 타입은 optional 처리해서 둘 중 하나만 변경해도 문제없게 함
- Context에서 상태 변경 함수(setNickname, setProfileImageUrl)를 제공하여 컴포넌트에서 바로 호출 가능함
- UserProfile 컴포넌트에서 상태 업데이트 후, UI 바로 반영(헤더 포함)
- 프로필 이미지 생성 API 타입 및 API, 커스텀 훅 제작(업로드할 이미지 파일이 올바른지 체크함)
- 프로필 이미지/닉네임 변경 시 토스트 알림 처리(성공/실패)
- "로그아웃" 버튼 클릭 시, 서버에서 쿠키를 삭제하는 서버 액션 logout 함수가 실행되어 로그아웃 처리(토스트 알림 처리 완료)
- router.push는 쿠키 삭제는 됐어도 렌더링은 캐시된 상태에서 일어나 헤더가 업데이트 되지 않아   window.location.replace("/login")로 로그인 페이지 이동
- 프로필 이미지 한번 바꾸면 기본 이미지로 못 돌아감
 

https://github.com/user-attachments/assets/ec1c1db3-7c5d-4f9e-8987-8dae22ae3b45


## :white_check_mark: Checklist

### PR Checklist

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] Assignee 및 Reviewer, 적절한 Label 지정
- [x] Development 설정

### Additional Notes

<!-- 추가 사항이 있을 경우, 작성해 주세요. -->

- [x] (없음)
