### PR TITLE
feat/53/마이페이지 오늘의감정

### DIFF
--- a/src/app/(with-header)/mypage/_components/TodayEmotion.tsx
+++ b/src/app/(with-header)/mypage/_components/TodayEmotion.tsx
@@ -1,9 +1,20 @@
+import EmotionLogs from "@/components/EmotionLogs";
+
 export default function TodayEmotion() {
+  const today = new Date();
+  const formattedDate = `${today.getFullYear()}.${String(
+    today.getMonth() + 1
+  ).padStart(2, "0")}.${String(today.getDate()).padStart(2, "0")}`;
+
   return (
-    <>
-      <h2 className="font-semibold text-black-600 text-lg lg:text-2lg">
-        오늘의 감정
-      </h2>
-    </>
+    <div>
+      <div className="flex justify-between">
+        <h2 className="font-semibold text-black-600 text-lg lg:text-2lg mb-6">
+          오늘의 감정
+        </h2>
+        <p className="text-lg lg:text-2lg text-blue-400">{formattedDate}</p>
+      </div>
+      <EmotionLogs />
+    </div>
   );
 }

--- a/src/components/EmotionLogs.tsx
+++ b/src/components/EmotionLogs.tsx
@@ -1,6 +1,10 @@
 "use client";
-import { useState } from "react";
-import { useCreateEmotionLogsToday } from "@/lib/hooks/useEmotionLogs";
+import { useEffect, useState } from "react";
+import {
+  useCreateEmotionLogsToday,
+  useEmotionLogsToday,
+} from "@/lib/hooks/useEmotionLogs";
+import { useMyData } from "@/lib/hooks/useUsers";
 import { Emotion, EmotionLabels } from "@/lib/types/emotionLogs";
 import Image from "next/image";
 import moved from "@/assets/emotion/moved.svg";
@@ -41,18 +45,31 @@ const emotionColors: Record<Emotion, { base: string; hover: string }> = {
 };
 
 export default function EmotionLogs() {
+  const { data: user } = useMyData();
   const [selectedEmotion, setSelectedEmotion] = useState<Emotion | null>(null);
+  const { data: todayEmotionData, isLoading } = useEmotionLogsToday(user?.id);
   const mutation = useCreateEmotionLogsToday();
+
+  useEffect(() => {
+    if (todayEmotionData?.emotion) {
+      setSelectedEmotion(todayEmotionData.emotion as Emotion);
+    }
+  }, [todayEmotionData]);
 
   const handleEmotionClick = (emotion: Emotion) => {
     setSelectedEmotion(emotion);
     mutation.mutate({ emotion });
   };
 
+  if (isLoading) return <div>로딩 중...</div>;
+
   return (
     <div className="flex justify-center gap-4">
       {emotions.map((emotion) => (
-        <div key={emotion.label} className="w-[56px] md:w-[96px] aspect-square">
+        <div
+          key={emotion.label}
+          className="min-w-[56px] max-w-[96px] w-full aspect-square"
+        >
           <div
             onClick={() => handleEmotionClick(emotion.label)}
             className={`w-full h-full flex items-center justify-center hover:bg-blue-100
@@ -73,10 +90,16 @@ export default function EmotionLogs() {
             <Image
               src={emotion.icon}
               alt={`${emotion.label} 아이콘`}
-              className="relative w-[32px] md:w-[48px] aspect-square"
+              className="relative w-[36px] md:w-[48px] aspect-square"
             />
           </div>
-          <p className="mt-2 font-semibold text-gray-400 text-center text-md md:text-lg">
+          <p
+            className={`mt-2 font-semibold text-center text-md md:text-lg ${
+              selectedEmotion === emotion.label
+                ? "text-sub-blue-600"
+                : "text-gray-400"
+            }`}
+          >
             {EmotionLabels[emotion.label]}
           </p>
         </div>

--- a/src/components/LoggedInHeader.tsx
+++ b/src/components/LoggedInHeader.tsx
@@ -53,9 +53,9 @@ export default function LoggedInHeader({
             검색
           </Link>
         </div>
-        <Link href="/mypage" className="flex gap-2 items-center">
+        <Link href="/mypage" className="flex gap-1 items-center">
           <ProfileImage src={image} size="sm" clickable />
-          <p className="font-semibold text-md lg:text-lg text-black-600">
+          <p className="font-semibold text-md lg:text-lg text-black-600  hover:bg-line-100 px-2 py-1 rounded-xl">
             {nickname}
           </p>
         </Link>

--- a/src/lib/hooks/useEmotionLogs.ts
+++ b/src/lib/hooks/useEmotionLogs.ts
@@ -27,10 +27,11 @@ export const useCreateEmotionLogsToday = () => {
 };
 
 // 오늘의 감정 조회 훅
-export const useEmotionLogsToday = (userId: number) => {
+export const useEmotionLogsToday = (userId?: number) => {
   return useQuery<EmotionLogsTodayResponse>({
     queryKey: ["emotionLogs", userId],
     queryFn: () => getEmotionLogs(userId!),
+    enabled: !!userId,
   });
 };
 


### PR DESCRIPTION
## :hash: Issue

<!-- 이슈 번호를 작성해 주세요. -->
- close #53 
## :memo: Description

<!-- PR 내용을 불렛 형식으로 자세하게 작성해 주세요. -->
### 마이 페이지의 오늘의 감정 컴포넌트 작업 내용입니다. ###
- TodayEmotion 컴포넌트 안에서 EmotionLogs 컴포넌트 불러옴
- Date 객체를 활용하여 오늘 날짜 렌더링
- EmotionLogs 컴포넌트에서 유저 정보 불러와 오늘의 감정 조회/요청(수정) 가능하도록 함
- 새로고침해도 선택된 감정 유지
- 각 감정 스타일링 반응형에 좀 더 유연하게 대응하도록 보완
- 메인 에피그램 페이지 또는 마이 페이지에서 감정 선택 시, 즉시 반영됨


https://github.com/user-attachments/assets/77a476be-8028-44ea-912e-8afa40afd465


## :white_check_mark: Checklist

### PR Checklist

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] Assignee 및 Reviewer, 적절한 Label 지정
- [x] Development 설정

### Additional Notes

<!-- 추가 사항이 있을 경우, 작성해 주세요. -->

- LoggedInHeader에서 닉네임 호버 시, 배경색 설정하여 스타일 추가
