### PR TITLE
feat/57/마이페이지 감정달력

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "framer-motion": "^12.9.1",
         "next": "15.3.1",
         "react": "^19.0.0",
+        "react-calendar": "^5.1.0",
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.56.1",
         "react-simple-typewriter": "^5.0.1",
@@ -4760,7 +4761,7 @@
       "version": "19.1.2",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.2.tgz",
       "integrity": "sha512-oxLPMytKchWGbnQM9O7D67uPa9paTNxO7jVoNMXgkkErULBPhPARCfkKL9ytcIJJRGjbsVwW4ugJzyFFvm/Tiw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -5451,6 +5452,14 @@
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@wojtekmaj/date-utils": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@wojtekmaj/date-utils/-/date-utils-1.5.1.tgz",
+      "integrity": "sha512-+i7+JmNiE/3c9FKxzWFi2IjRJ+KzZl1QPu6QNrsgaa2MuBgXvUy4gA1TVzf/JMdIIloB76xSKikTWuyYAIVLww==",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/date-utils?sponsor=1"
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -7015,7 +7024,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -8600,6 +8609,17 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/get-user-locale": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/get-user-locale/-/get-user-locale-2.3.2.tgz",
+      "integrity": "sha512-O2GWvQkhnbDoWFUJfaBlDIKUEdND8ATpBXD6KXcbhxlfktyD/d8w6mkzM/IlQEqGZAMz/PW6j6Hv53BiigKLUQ==",
+      "dependencies": {
+        "mem": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/get-user-locale?sponsor=1"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -9542,8 +9562,7 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -9979,7 +9998,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -10053,6 +10071,17 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/map-age-cleaner": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "dependencies": {
+        "p-defer": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/map-or-similar": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/map-or-similar/-/map-or-similar-1.5.0.tgz",
@@ -10076,6 +10105,21 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/mem": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-8.1.1.tgz",
+      "integrity": "sha512-qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==",
+      "dependencies": {
+        "map-age-cleaner": "^0.1.3",
+        "mimic-fn": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/mem?sponsor=1"
       }
     },
     "node_modules/memfs": {
@@ -10163,6 +10207,14 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
+      "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/min-indent": {
@@ -10633,6 +10685,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/p-limit": {
@@ -11317,6 +11377,30 @@
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-calendar": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/react-calendar/-/react-calendar-5.1.0.tgz",
+      "integrity": "sha512-09o/rQHPZGEi658IXAJtWfra1N69D1eFnuJ3FQm9qUVzlzNnos1+GWgGiUeSs22QOpNm32aoVFOimq0p3Ug9Eg==",
+      "dependencies": {
+        "@wojtekmaj/date-utils": "^1.1.3",
+        "clsx": "^2.0.0",
+        "get-user-locale": "^2.2.1",
+        "warning": "^4.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/react-calendar?sponsor=1"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-confetti": {
@@ -13241,6 +13325,14 @@
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
       "dev": true
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
     },
     "node_modules/watchpack": {
       "version": "2.4.2",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "framer-motion": "^12.9.1",
     "next": "15.3.1",
     "react": "^19.0.0",
+    "react-calendar": "^5.1.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.56.1",
     "react-simple-typewriter": "^5.0.1",

--- a/src/app/(with-header)/mypage/_components/MonthlyEmotion.tsx
+++ b/src/app/(with-header)/mypage/_components/MonthlyEmotion.tsx
@@ -1,9 +1,119 @@
+"use client";
+import { useState } from "react";
+import { useMyData } from "@/lib/hooks/useUsers";
+import { useEmotionLogsMonthly } from "@/lib/hooks/useEmotionLogs";
+import { Emotion } from "@/lib/types/emotionLogs";
+import Calendar, { CalendarProps } from "react-calendar";
+import SelectOption from "@/components/SelectOption";
+import Image from "next/image";
+import moved from "@/assets/emotion/moved.svg";
+import happy from "@/assets/emotion/happy.svg";
+import worried from "@/assets/emotion/worried.svg";
+import sad from "@/assets/emotion/sad.svg";
+import angry from "@/assets/emotion/angry.svg";
+import chevronLeft from "@/assets/icons/chevron-left.svg";
+import chevornRight from "@/assets/icons/chevron-right.svg";
+import "react-calendar/dist/Calendar.css";
+import "./calendar.css";
+
 export default function MonthlyEmotion() {
+  const [value, setValue] = useState(new Date());
+  const [filter, setFilter] = useState<string>("");
+  const { data: user } = useMyData();
+  const { data, isLoading } = useEmotionLogsMonthly({
+    userId: user?.id,
+    year: value.getFullYear(),
+    month: value.getMonth() + 1,
+  });
+
+  const emotionOptions = [
+    { label: "전체", onClick: () => setFilter("") },
+    { label: "감동", onClick: () => setFilter(Emotion.MOVED) },
+    { label: "기쁨", onClick: () => setFilter(Emotion.HAPPY) },
+    { label: "고민", onClick: () => setFilter(Emotion.WORRIED) },
+    { label: "슬픔", onClick: () => setFilter(Emotion.SAD) },
+    { label: "분노", onClick: () => setFilter(Emotion.ANGRY) },
+  ];
+
+  const emotionIcon = [
+    { label: Emotion.MOVED, icon: moved },
+    { label: Emotion.HAPPY, icon: happy },
+    { label: Emotion.WORRIED, icon: worried },
+    { label: Emotion.SAD, icon: sad },
+    { label: Emotion.ANGRY, icon: angry },
+  ];
+
+  const emotions =
+    data?.map((log) => ({
+      date: log.createdAt.slice(0, 10),
+      emotion: log.emotion,
+    })) ?? [];
+
+  const filteredEmotions = filter
+    ? emotions.filter((log) => log.emotion === filter)
+    : emotions;
+
+  const tileContent = ({ date, view }: { date: Date; view: string }) => {
+    if (view === "month") {
+      const dateStr = `${date.getFullYear()}-${String(
+        date.getMonth() + 1
+      ).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+
+      const found = filteredEmotions.find((e) => e.date === dateStr);
+      if (!found) return null;
+
+      const foundEmotion = emotionIcon.find((e) => e.label === found.emotion);
+      if (!foundEmotion) return null;
+
+      return (
+        <div className="md:mt-2">
+          <Image
+            src={foundEmotion.icon}
+            alt={foundEmotion.label}
+            className="w-[20px] h-[20px] md:w-[32px] md:h-[32px]"
+          />
+        </div>
+      );
+    }
+    return null;
+  };
+
+  const handleChange: CalendarProps["onChange"] = (value) => {
+    if (value instanceof Date) setValue(value);
+  };
+
+  if (isLoading) return <div>로딩 중...</div>;
+
   return (
-    <>
-      <h2 className="font-semibold text-black-600 text-lg lg:text-2lg">
-        2025년 5월
-      </h2>
-    </>
+    <div className="relative">
+      <Calendar
+        onChange={handleChange}
+        value={value}
+        formatDay={(locale, date) => date.getDate().toString()}
+        prev2Label={null}
+        next2Label={null}
+        prevLabel={<Image src={chevronLeft} alt="이전 월" />}
+        nextLabel={<Image src={chevornRight} alt="다음 월" />}
+        tileContent={tileContent}
+        calendarType="hebrew"
+        tileClassName={({ date, view, activeStartDate }) => {
+          if (view !== "month") return "";
+
+          const viewMonth = activeStartDate.getMonth();
+          const dateMonth = date.getMonth();
+          const day = date.getDay();
+          const isSameMonth = dateMonth === viewMonth;
+
+          if (!isSameMonth) return "dimmed";
+          if (day === 0) return "sunday";
+          if (day === 6) return "saturday";
+          if (day === 5) return "friday";
+          return "";
+        }}
+      />
+      <div className="mb-4 top-1 absolute right-[28%] md:right-[16%]">
+        <SelectOption options={emotionOptions} />
+      </div>
+    </div>
   );
 }

--- a/src/app/(with-header)/mypage/_components/UserContainer.tsx
+++ b/src/app/(with-header)/mypage/_components/UserContainer.tsx
@@ -6,7 +6,7 @@ import UserProfile from "./UserProfile";
 export default function UserContainer() {
   return (
     <div
-      className="relative bg-blue-100 w-full h-[1004px] rounded-3xl mt-16 lg:mt-32"
+      className="relative bg-blue-100 w-full rounded-3xl mt-16 lg:mt-32"
       style={{
         filter: "drop-shadow(0px 0px 36px rgba(0,0,0,0.05))",
       }}

--- a/src/app/(with-header)/mypage/_components/calendar.css
+++ b/src/app/(with-header)/mypage/_components/calendar.css
@@ -1,0 +1,134 @@
+/* 기본 캘린더 스타일링 */
+.react-calendar {
+  width: 100%;
+  line-height: 1.125em;
+  border: none;
+  font-family: "pretendard";
+}
+
+/* 캘린더 네비게이션 */
+.react-calendar__navigation {
+  justify-content: flex-end;
+  margin-bottom: 0;
+}
+
+/* 연도, 월 라벨 */
+.react-calendar__navigation__label {
+  position: absolute;
+  left: 0;
+  top: 0;
+  font-weight: 600;
+  color: #373737;
+  font-size: 1.2rem;
+  background-color: transparent !important;
+}
+
+.react-calendar__navigation button {
+  font-size: 1rem;
+  cursor: pointer;
+  padding: 0.5em;
+}
+
+/* 페이지네이션 */
+.react-calendar__navigation__arrow {
+  background-color: transparent !important;
+}
+
+/* 요일 스타일 */
+.react-calendar__month-view__weekdays__weekday {
+  font-weight: 600;
+  font-size: 14px;
+  aspect-ratio: 1/1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #999;
+}
+
+.react-calendar__month-view__weekdays__weekday abbr {
+  text-decoration: none;
+  cursor: default;
+}
+
+/* 달력 그리드 */
+.react-calendar__month-view__days {
+  display: grid !important;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 5px;
+}
+
+.react-calendar__month-view__days__day {
+  aspect-ratio: 1/1;
+  width: 100%;
+  aspect-ratio: 1/1;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+/* 날짜 스타일 */
+.react-calendar__tile {
+  background: none;
+  border-radius: 8px;
+  transition: background 0.3s;
+  color: #373737;
+}
+
+/* 오늘 날짜 */
+.react-calendar__tile--now {
+  border: 2px solid #f87171 !important;
+  color: #f87171;
+  font-weight: bold;
+  background-color: transparent !important;
+}
+
+/* 오늘 날짜 호버 스타일 */
+.react-calendar__tile--now:enabled:hover {
+  background-color: #e6e6e6 !important;
+}
+
+/* 오늘 날짜 선택 스타일 */
+.react-calendar__tile--now:enabled:focus {
+  background-color: transparent !important;
+}
+
+/* 날짜 호버 스타일 */
+.react-calendar__tile:hover {
+  background-color: #e6e6e6;
+}
+
+.react-calendar__tile--active:enabled:focus {
+  background-color: #cbd3e1 !important;
+}
+
+/* 비활성 날짜 (다른 달) */
+.react-calendar__month-view__days__day--neighboringMonth {
+  color: #d1d5db;
+}
+
+/* 일 빨간 폰트 */
+.react-calendar__month-view__weekdays__weekday:nth-child(1) abbr {
+  color: #e46e80;
+}
+
+/* 토 파란 폰트 */
+.react-calendar__month-view__weekdays__weekday:nth-child(7) abbr {
+  color: #5195ee;
+}
+
+/* 일요일 날짜 색상 */
+.react-calendar__tile.sunday abbr {
+  color: #e46e80;
+}
+
+/* 금요일 날짜 색상 */
+.react-calendar__tile.friday abbr {
+  color: #373737;
+}
+
+/* 토요일 날짜 색상 */
+.react-calendar__tile.saturday abbr {
+  color: #5195ee;
+}

--- a/src/components/EmotionLogs.tsx
+++ b/src/components/EmotionLogs.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/lib/hooks/useEmotionLogs";
 import { useMyData } from "@/lib/hooks/useUsers";
 import { Emotion, EmotionLabels } from "@/lib/types/emotionLogs";
+import { toast } from "react-toastify";
 import Image from "next/image";
 import moved from "@/assets/emotion/moved.svg";
 import happy from "@/assets/emotion/happy.svg";
@@ -59,6 +60,7 @@ export default function EmotionLogs() {
   const handleEmotionClick = (emotion: Emotion) => {
     setSelectedEmotion(emotion);
     mutation.mutate({ emotion });
+    toast.success("오늘의 감정이 선택되었습니다.");
   };
 
   if (isLoading) return <div>로딩 중...</div>;

--- a/src/components/SelectOption.tsx
+++ b/src/components/SelectOption.tsx
@@ -24,7 +24,7 @@ export default function SelectOption({ options }: SelectOptionProps) {
     <div ref={ref} className="relative inline-block">
       <button
         onClick={() => setIsOpen((prev) => !prev)}
-        className="flex gap-1 cursor-pointer text-md items-center bg-background-100 text-gray-300 border border-blue-950 font-semibold px-3 py-1 rounded-lg"
+        className="flex gap-1 cursor-pointer text-md items-center bg-background-100 text-gray-300 font-semibold px-3 py-1 rounded-lg"
       >
         {selectedLabel || "필터"}
         <Image src={arrow} width={16} height={16} alt="셀렉트 옵션 아이콘" />

--- a/src/lib/types/emotionLogs.ts
+++ b/src/lib/types/emotionLogs.ts
@@ -59,7 +59,7 @@ export type EmotionLogsMonthlyResponse = z.infer<
 
 // 월별 감정 조회 파라미터 API 타입
 export const getEmotionLogsMonthlyParamsShema = z.object({
-  userId: z.number(),
+  userId: z.number().optional(),
   year: z.number(),
   month: z.number(),
 });


### PR DESCRIPTION
## :hash: Issue

<!-- 이슈 번호를 작성해 주세요. -->
- close #57 
## :memo: Description

<!-- PR 내용을 불렛 형식으로 자세하게 작성해 주세요. -->
**⚠️ react-calendar 라이브러리를 설치하였습니다.**

### 마이 페이지의 감정 달력 컴포넌트 작업 내용입니다. ###
- 현재 로그인한 유저 데이터와 해당 유저의 감정 데이터를 불러옴
- 공통 컴포넌트 셀렉트 옵션을 사용하여 필터 옵션 정의
- 옵션 클릭 시, 필터 상태 변경되고 필터링된 감정 데이터만 사용
- css 파일을 만들어 캘린더 스타일링 및 반응형 구현
- 메인 에피그램 페이지 또는 마이 페이지에서 감정 선택 시, 즉시 업데이트됨

https://github.com/user-attachments/assets/1d6c67af-fa92-4828-8f5f-bc887f0f1e9f


PC 
![스크린샷 2025-05-22 153046](https://github.com/user-attachments/assets/c5613456-d8fe-4372-8218-082eca62c8fa)

Mobile
![스크린샷 2025-05-22 153010](https://github.com/user-attachments/assets/7771cedd-e5b8-4c51-a94c-fd436bb360db)



## :white_check_mark: Checklist

### PR Checklist

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] Assignee 및 Reviewer, 적절한 Label 지정
- [x] Development 설정

### Additional Notes

<!-- 추가 사항이 있을 경우, 작성해 주세요. -->

- 감정 선택 시, 토스트 알림 처리
