### PR TITLE
feat/61/마이페이지 내에피그램/댓글

### DIFF
--- a/src/app/(with-header)/mypage/_components/MyComment.tsx
+++ b/src/app/(with-header)/mypage/_components/MyComment.tsx
@@ -1,0 +1,80 @@
+"use client";
+import { useEffect, useState } from "react";
+import { UpdateCommentResponse } from "@/lib/types/comments";
+import { UserCommentListResponse } from "@/lib/types/users";
+import Button from "@/components/Button";
+import CommentItem from "@/components/CommentItem";
+import Empty from "@/components/Empty";
+import Image from "next/image";
+import plus from "@/assets/icons/plus.svg";
+
+export default function MyComment({
+  data,
+  userId,
+  handleLoadMore,
+}: {
+  data: UserCommentListResponse;
+  userId: number;
+  handleLoadMore: (e: React.MouseEvent) => void;
+}) {
+  const [commentList, setCommentList] = useState(data?.list || []);
+
+  useEffect(() => {
+    if (data?.list) {
+      setCommentList(data.list);
+    }
+  }, [data]);
+
+  const handleUpdateComment = (updatedComment: UpdateCommentResponse) => {
+    setCommentList((prevList) =>
+      prevList.map((comment) =>
+        comment.id === updatedComment.id ? updatedComment : comment
+      )
+    );
+  };
+
+  const handleDeleteComment = (id: number) => {
+    setCommentList((prevList) =>
+      prevList.filter((comment) => comment.id !== id)
+    );
+  };
+
+  return (
+    <>
+      {data?.list.length === 0 && <Empty myComment />}
+
+      {commentList.map((comment) => (
+        <div key={comment.id}>
+          <CommentItem
+            epigramId={comment.epigramId}
+            commentId={comment.id}
+            image={comment.writer.image}
+            nickname={comment.writer.nickname}
+            content={comment.content}
+            updatedAt={comment.updatedAt}
+            onUpdate={handleUpdateComment}
+            onDelete={handleDeleteComment}
+            isMine={userId === comment.writer.id}
+          />
+        </div>
+      ))}
+
+      {(commentList.length ?? 0) < (data?.totalCount ?? 0) && (
+        <Button
+          variant="outline"
+          size="xl"
+          isRoundedFull
+          className="mx-auto mt-14 w-[152px] lg:w-[240px]"
+          onClick={handleLoadMore}
+        >
+          <Image
+            src={plus}
+            alt="더보기 아이콘"
+            className="lg:mr-2 w-[20px] lg:w-[24px]"
+          />
+          댓글 더보기
+        </Button>
+      )}
+    </>
+  );
+}

--- a/src/app/(with-header)/mypage/_components/MyEpigram.tsx
+++ b/src/app/(with-header)/mypage/_components/MyEpigram.tsx
@@ -1,0 +1,49 @@
+"use client";
+import { EpigramListResponse } from "@/lib/types/epigrams";
+import Button from "@/components/Button";
+import EpigramItem from "@/components/EpigramItem";
+import Empty from "@/components/Empty";
+import Image from "next/image";
+import plus from "@/assets/icons/plus.svg";
+
+export default function MyEpigram({
+  data,
+  handleLoadMore,
+}: {
+  data: EpigramListResponse;
+  handleLoadMore: (e: React.MouseEvent) => void;
+}) {
+  return (
+    <>
+      {data?.list.length === 0 && <Empty myEpigram />}
+
+      {data?.list.map((epigram) => (
+        <div key={epigram.id} className="mb-4 lg:mb-8">
+          <EpigramItem
+            content={epigram.content}
+            author={epigram.author}
+            tags={epigram.tags}
+            id={epigram.id}
+          />
+        </div>
+      ))}
+
+      {(data?.list?.length ?? 0) < (data?.totalCount ?? 0) && (
+        <Button
+          variant="outline"
+          size="xl"
+          isRoundedFull
+          className="mx-auto mt-14 w-[152px] lg:w-[240px]"
+          onClick={handleLoadMore}
+        >
+          <Image
+            src={plus}
+            alt="더보기 아이콘"
+            className="lg:mr-2 w-[20px] lg:w-[24px]"
+          />
+          에피그램 더보기
+        </Button>
+      )}
+    </>
+  );
+}

--- a/src/app/(with-header)/mypage/_components/MyItems.tsx
+++ b/src/app/(with-header)/mypage/_components/MyItems.tsx
@@ -1,9 +1,72 @@
+"use client";
+import { useState } from "react";
+import { useMyData, useUserCommentList } from "@/lib/hooks/useUsers";
+import { useEpigramList } from "@/lib/hooks/useEpigrams";
+import MyEpigram from "./MyEpigram";
+import MyComment from "./MyComment";
+
 export default function MyItems() {
+  const [activeTab, setActiveTab] = useState<"epigram" | "comment">("epigram");
+  const [limit, setLimit] = useState(3);
+  const { data: user } = useMyData();
+  const {
+    data: myEpigram,
+    isLoading: isLoadingEpigram,
+    isError: isErrorEpigram,
+  } = useEpigramList({
+    limit: limit,
+    writerId: user?.id,
+  });
+  const {
+    data: myComment,
+    isLoading: isLoadingComment,
+    isError: isErrorComment,
+  } = useUserCommentList(user?.id, {
+    limit,
+  });
+
+  const handleLoadMore = (e: React.MouseEvent) => {
+    e.preventDefault();
+    setLimit((prevLimit) => prevLimit + 3);
+  };
+
+  if (isLoadingEpigram || isLoadingComment) return <p>로딩 중...</p>;
+  if (isErrorEpigram || isErrorComment) return <p>에러가 발생했습니다.</p>;
+  if (!user || !myEpigram || !myComment)
+    return <p>데이터를 불러올 수 없습니다.</p>;
+
   return (
     <div className="max-w-[640px] w-full mx-auto px-6 md:px-0 mt-14">
-      <h2 className="font-semibold text-black-600 text-lg lg:text-2lg">
-        내 에피그램
-      </h2>
+      <div className="flex gap-4 mb-12">
+        <button
+          className={`font-semibold  text-lg lg:text-2lg cursor-pointer ${
+            activeTab === "epigram" ? "text-black-600" : "text-gray-300"
+          }`}
+          onClick={() => setActiveTab("epigram")}
+        >
+          내 에피그램 ({myEpigram?.totalCount ?? 0})
+        </button>
+
+        <button
+          className={`font-semibold  text-lg lg:text-2lg cursor-pointer ${
+            activeTab === "comment" ? "text-black-600" : "text-gray-300"
+          }`}
+          onClick={() => setActiveTab("comment")}
+        >
+          내 댓글 ({myComment?.totalCount ?? 0})
+        </button>
+      </div>
+
+      {activeTab === "epigram" && (
+        <MyEpigram data={myEpigram} handleLoadMore={handleLoadMore} />
+      )}
+      {activeTab === "comment" && (
+        <MyComment
+          data={myComment}
+          userId={user?.id}
+          handleLoadMore={handleLoadMore}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/CommentItem.tsx
+++ b/src/components/CommentItem.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react";
 import { useDeleteComment, useUpdateComment } from "@/lib/hooks/useComments";
 import { UpdateCommentResponse } from "@/lib/types/comments";
+import { toast } from "react-toastify";
 import formatTime from "@/lib/utils/formatTime";
 import Link from "next/link";
 import ProfileImage from "./ProfileImage";
@@ -48,6 +49,7 @@ export default function CommentItem({
         onSuccess: (updateComment) => {
           onUpdate(updateComment);
           setIsEditing(false);
+          toast.success("댓글이 수정되었습니다.");
         },
       }
     );
@@ -57,6 +59,7 @@ export default function CommentItem({
     deleteComment.mutate(commentId, {
       onSuccess: () => {
         onDelete?.(commentId);
+        toast.success("댓글이 삭제되었습니다.");
       },
     });
   };

--- a/src/lib/hooks/useUsers.ts
+++ b/src/lib/hooks/useUsers.ts
@@ -53,12 +53,13 @@ export const useUserData = (id: number) => {
 
 // 유저 댓글 목록 조회 훅
 export const useUserCommentList = (
-  id: number,
+  id: number | undefined,
   params: GetUserCommentListParams
 ) => {
   return useQuery<UserCommentListResponse>({
     queryKey: ["users", id, params],
     queryFn: () => getUserCommentList(id!, params),
+    enabled: !!id,
   });
 };
 


### PR DESCRIPTION
## :hash: Issue

<!-- 이슈 번호를 작성해 주세요. -->
- close #61 
## :memo: Description

<!-- PR 내용을 불렛 형식으로 자세하게 작성해 주세요. -->


### 마이 페이지의 내 에피그램 및 댓글 컴포넌트 작업 내용입니다. ###
MyItems 컴포넌트
- 현재 보고 있는 탭 상태를 관리함(epigram 또는 comment)
- useMyData 훅을 사용하여 로그인한 유저 정보를 불러옴
- useEpigramList 훅을 사용하여 내가 쓴 에피그램 목록을 불러옴
- useUserCommentList 훅을 사용하여 내가 쓴 댓글 목록을 불러옴
- 유저 정보나 데이터를 못 불러올 때 또는 로딩/에러 각각 처리
- 내 에피그램 또는 내 댓글 텍스트를 버튼 태그로 감싸고, 클릭 시 activeTab 상태 변경
- 선택된 탭에 맞는 컴포넌트를 렌더링함(MyEpigram 또는 MyComment)
  - MyEpigram : 불러온 내가 쓴 에피그램 목록 데이터와 더보기 이벤트 핸들러를 prop으로 넘겨줌
  - MyComment : 불러온 내가 쓴 댓글 목록 데이터, 더보기 이벤트 핸들러와 유저 ID를 prop으로 넘겨줌
  - 공통 컴포넌트 Empty 컴포넌트 활용하여 0개일 때 처리
  
![스크린샷 2025-05-26 122915](https://github.com/user-attachments/assets/a4e25350-148c-49f6-8b74-478ab0923a59)
![스크린샷 2025-05-26 122924](https://github.com/user-attachments/assets/39c58d61-2372-4b7b-8408-2d5db861e1fe)

https://github.com/user-attachments/assets/333b1b3b-b8dd-4080-9b86-a248a558ec57

## :white_check_mark: Checklist
### PR Checklist
<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] Assignee 및 Reviewer, 적절한 Label 지정
- [x] Development 설정

### Additional Notes

<!-- 추가 사항이 있을 경우, 작성해 주세요. -->

- 댓글 수정/삭제 시 토스트 알림 처리 로직 추가
