### PR TITLE
feat/63/회원가입페이지

### DIFF
--- a/src/app/(with-header)/login/_components/LoginForm.tsx
+++ b/src/app/(with-header)/login/_components/LoginForm.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useLogin } from "@/lib/hooks/useAuth";
 import { LoginRequest, loginRequestSchema } from "@/lib/types/auth";
+import { toast } from "react-toastify";
 import Link from "next/link";
 import Image from "next/image";
 import logo from "@/assets/logo/logo-lg.svg";
@@ -35,27 +36,24 @@ export default function LoginForm() {
     try {
       await login(data);
       await queryClient.invalidateQueries({ queryKey: ["users"] });
+      toast.success("로그인에 성공했습니다.");
       router.push("/epigrams");
-    } catch (error) {
-      console.error("로그인 실패", error);
+    } catch {
       setError("email", {
         type: "manual",
         message: "이메일 혹은 비밀번호를 확인해 주세요.",
       });
+      toast.error("로그인에 실패했습니다.");
     }
   };
 
   return (
-    <div className="relative mx-auto max-w-[640px] min-w-[312px] mt-[120px] md:mt-[150px] px-4 md:px-0">
-      <Link href="/">
-        <Image
-          src={logo}
-          alt="로고"
-          width={172}
-          height={48}
-          className="mx-auto mb-[50px]"
-        />
-      </Link>
+    <div className="relative mx-auto max-w-[640px] min-w-[312px] mt-40 mb-40 md:mt-35 md:mb-35 px-4 md:px-0">
+      <div className="flex justify-center mb-12">
+        <Link href="/">
+          <Image src={logo} alt="로고" width={172} height={48} />
+        </Link>
+      </div>
       <form onSubmit={handleSubmit(onSubmit)}>
         <Input
           type="email"
@@ -78,16 +76,16 @@ export default function LoginForm() {
             height={24}
             alt="비밀번호 눈 아이콘"
             onClick={() => setIsShowPassword((prev) => !prev)}
-            className="cursor-pointer absolute top-[28px] lg:top-[38px] right-4"
+            className="cursor-pointer absolute top-7 lg:top-9 right-4"
           />
         </div>
         <Button
           type="submit"
           size="xl"
-          className="w-full mt-[20px]"
+          className="w-full mt-5"
           disabled={!isValid || isSubmitting}
         >
-          로그인
+          로그인하기
         </Button>
       </form>
       <p className="mt-12 text-center font-medium text-md lg:text-lg text-blue-400">

--- a/src/app/(with-header)/signup/_components/SignUpForm.tsx
+++ b/src/app/(with-header)/signup/_components/SignUpForm.tsx
@@ -1,0 +1,140 @@
+"use client";
+import { useForm } from "react-hook-form";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useLogin, useSignup } from "@/lib/hooks/useAuth";
+import { SignupRequest, signupRequestSchema } from "@/lib/types/auth";
+import { AxiosError } from "axios";
+import { toast } from "react-toastify";
+import Link from "next/link";
+import Image from "next/image";
+import logo from "@/assets/logo/logo-lg.svg";
+import eye from "@/assets/icons/eye.svg";
+import eyeVisible from "@/assets/icons/eye-visible.svg";
+import Input from "@/components/Input";
+import Button from "@/components/Button";
+import SocialLogin from "@/components/SocialLogin";
+
+export default function SignUpForm() {
+  const { mutateAsync: signup } = useSignup();
+  const { mutateAsync: login } = useLogin();
+  const router = useRouter();
+  const [isShowPassword, setIsShowPassword] = useState(false);
+  const [isShowPasswordConfirm, setIsShowPasswordConfirm] = useState(false);
+  const {
+    register,
+    handleSubmit,
+    trigger,
+    setError,
+    formState: { errors, isSubmitting, isValid },
+  } = useForm<SignupRequest>({
+    resolver: zodResolver(signupRequestSchema),
+    mode: "onChange",
+  });
+
+  const onSubmit = async (data: SignupRequest) => {
+    try {
+      await signup(data);
+      const { email, password } = data;
+      await login({ email, password });
+      toast.success("회원가입에 성공했습니다.");
+      router.push("/epigrams");
+    } catch (err) {
+      const error = err as AxiosError;
+      const status = error?.response?.status;
+
+      setError(status === 500 ? "nickname" : "email", {
+        type: "manual",
+        message:
+          status === 500
+            ? "이미 존재하는 닉네임입니다."
+            : "이미 존재하는 이메일입니다.",
+      });
+      toast.error("회원가입에 실패했습니다.");
+    }
+  };
+
+  return (
+    <div className="relative mx-auto max-w-[640px] min-w-[312px] mt-14 mb-14 md:mt-20 md:mb-20 px-4 md:px-0">
+      <div className="flex justify-center mb-12">
+        <Link href="/">
+          <Image src={logo} alt="로고" width={172} height={48} />
+        </Link>
+      </div>
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        className="space-y-5 md:space-y-10"
+      >
+        <Input
+          label="이메일"
+          type="email"
+          placeholder="이메일을 입력하세요"
+          {...register("email")}
+          error={errors.email?.message}
+        />
+        <div>
+          <div className="relative">
+            <Input
+              label="비밀번호"
+              type={isShowPassword ? "text" : "password"}
+              placeholder="비밀번호를 입력하세요"
+              {...register("password", {
+                onBlur: () => trigger("password"),
+              })}
+              error={errors.password?.message}
+            />
+            <Image
+              src={isShowPassword ? eyeVisible : eye}
+              width={24}
+              height={24}
+              alt="비밀번호 눈 아이콘"
+              onClick={() => setIsShowPassword((prev) => !prev)}
+              className="cursor-pointer absolute top-12 lg:top-15 right-4"
+            />
+          </div>
+          <div className="relative">
+            <Input
+              type={isShowPasswordConfirm ? "text" : "password"}
+              placeholder="비밀번호를 확인해 주세요"
+              {...register("passwordConfirmation", {
+                onBlur: () => trigger("passwordConfirmation"),
+              })}
+              error={errors.passwordConfirmation?.message}
+            />
+            <Image
+              src={isShowPasswordConfirm ? eyeVisible : eye}
+              width={24}
+              height={24}
+              alt="비밀번호 눈 아이콘"
+              onClick={() => setIsShowPasswordConfirm((prev) => !prev)}
+              className="cursor-pointer absolute top-7 lg:top-9 right-4"
+            />
+          </div>
+        </div>
+        <Input
+          label="닉네임"
+          type="text"
+          placeholder="닉네임을 입력하세요"
+          {...register("nickname")}
+          error={errors.nickname?.message}
+        />
+        <Button
+          type="submit"
+          size="xl"
+          className="w-full mt-5"
+          disabled={!isValid || isSubmitting}
+        >
+          회원가입하기
+        </Button>
+      </form>
+      <p className="mt-12 text-center font-medium text-md lg:text-lg text-blue-400">
+        이미 회원이신가요?&nbsp;
+        <Link href="/login" className="underline text-black-500">
+          로그인하기
+        </Link>
+      </p>
+      <SocialLogin />
+    </div>
+  );
+}

--- a/src/app/(with-header)/signup/page.tsx
+++ b/src/app/(with-header)/signup/page.tsx
@@ -1,3 +1,5 @@
+import SignUpForm from "./_components/SignUpForm";
+
 export default function Page() {
-  return <div>회원가입 페이지</div>;
+  return <SignUpForm />;
 }

--- a/src/lib/apis/auth.ts
+++ b/src/lib/apis/auth.ts
@@ -8,19 +8,18 @@ import {
   refreshTokenResponseSchema,
   OauthRequest,
   SignupRequest,
-  signupRequestSchema,
   OauthAppRequest,
   OAuthAppResponse,
   oauthAppResponseSchema,
 } from "../types/auth";
 
 // 회원가입 요청 API
-export const signup = async (params: SignupRequest) => {
+export const signup = async (data: SignupRequest) => {
   const response = await axiosClientHelper.post<AuthResponse>(
     "/auth/signUp",
-    params
+    data
   );
-  return safeResponse(response.data, signupRequestSchema);
+  return safeResponse(response.data, authResponseSchema);
 };
 
 // 로그인 요청 API

--- a/src/lib/hooks/useAuth.ts
+++ b/src/lib/hooks/useAuth.ts
@@ -19,7 +19,7 @@ import {
 // 회원가입 훅
 export const useSignup = () => {
   return useMutation({
-    mutationFn: (params: SignupRequest) => signup(params),
+    mutationFn: (data: SignupRequest) => signup(data),
   });
 };
 

--- a/src/lib/types/auth.ts
+++ b/src/lib/types/auth.ts
@@ -24,7 +24,6 @@ export const signupRequestSchema = z
       .string()
       .min(1, { message: "닉네임을 입력해 주세요." })
       .max(30, { message: "닉네임은 30자 이하로 입력해 주세요." }),
-    image: z.string().url().optional(),
   })
   .refine((data) => data.password === data.passwordConfirmation, {
     message: "비밀번호가 일치하지 않습니다.",


### PR DESCRIPTION
## :hash: Issue

<!-- 이슈 번호를 작성해 주세요. -->
- close #63 
## :memo: Description

<!-- PR 내용을 불렛 형식으로 자세하게 작성해 주세요. -->
### 회원가입 페이지 작업 내용입니다. ###
SignUpForm 회원가입 폼
- 공통 API auth 활용
- 공통 컴포넌트 버튼, 인풋, 소셜 로그인 컴포넌트 활용
- 이메일, 비밀번호, 비밀번호 확인, 닉네임 유효성 검사
  - 500 에러면 닉네임 중복 에러 메시지 표시, 그렇지 않으면 중복 이메일 에러 메시지 표시
  - 비밀번호 한글로 입력하면 숫자, 영어, 특수문자 포함 8자 이상 입력해달라는 에러 메시지 표시
  - 비밀번호 일치하는지 확인 검사
  - 닉네임 30자 이상 넘으면 에러 메시지 표시 
- 회원가입 성공하면 메인 에피그램 페이지("/epigrams")로 이동
  - onSubmit 함수 내에서 회원가입 요청을 보내고, 그중 email, password 로그인용 정보를 추출해서 바로 로그인 요청을 보냄
 - 회원가입 성공/실패 시 토스트 알림 처리
 - 반응형 구현
## :white_check_mark: Checklist

https://github.com/user-attachments/assets/e7091be0-d97e-4f1c-8080-70929309451f

![스크린샷 2025-05-27 112731](https://github.com/user-attachments/assets/47a05882-6ff2-41a5-af1d-69409576d9a6)


### PR Checklist

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] Assignee 및 Reviewer, 적절한 Label 지정
- [x] Development 설정

### Additional Notes

<!-- 추가 사항이 있을 경우, 작성해 주세요. -->

- [x] (없음)
