### PR TITLE
bug/78/로그인페이지

### DIFF
--- a/src/components/EmotionLogs.tsx
+++ b/src/components/EmotionLogs.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/lib/hooks/useEmotionLogs";
 import { useMyData } from "@/lib/hooks/useUsers";
 import { Emotion, EmotionLabels } from "@/lib/types/emotionLogs";
+import { isAxiosError } from "axios";
 import { toast } from "react-toastify";
 import LoadingSpinner from "./LoadingSpinner";
 import RetryError from "./RetryError";
@@ -60,9 +61,22 @@ export default function EmotionLogs() {
   }, [todayEmotionData]);
 
   const handleEmotionClick = (emotion: Emotion) => {
-    setSelectedEmotion(emotion);
-    mutation.mutate({ emotion });
-    toast.success("오늘의 감정이 선택되었습니다.");
+    mutation.mutate(
+      { emotion },
+      {
+        onSuccess: () => {
+          setSelectedEmotion(emotion);
+          toast.success("오늘의 감정이 선택되었습니다.");
+        },
+        onError: (error) => {
+          if (isAxiosError(error) && error.response?.status === 401) {
+            toast.error("로그인 후, 이용 가능합니다.");
+          } else {
+            toast.error("감정 선택에 실패했습니다.");
+          }
+        },
+      }
+    );
   };
 
   if (isUserLoading || isLoading) return <LoadingSpinner />;

--- a/src/lib/hooks/useAuth.ts
+++ b/src/lib/hooks/useAuth.ts
@@ -27,8 +27,10 @@ export const useSignUp = () => {
 export const useLogin = () => {
   return useMutation<AuthResponse, Error, LoginRequest>({
     mutationFn: login,
-    onError: (error) => {
-      console.error("Login error:", error);
+    onSuccess: () => {
+      if (typeof window !== "undefined") {
+        sessionStorage.removeItem("hasRedirectedFor401");
+      }
     },
   });
 };
@@ -37,9 +39,6 @@ export const useLogin = () => {
 export const useRefreshToken = () => {
   return useMutation<RefreshTokenResponse, Error, void>({
     mutationFn: refreshToken,
-    onError: (error) => {
-      console.error("Token refresh error:", error);
-    },
   });
 };
 

--- a/src/lib/hooks/useUsers.ts
+++ b/src/lib/hooks/useUsers.ts
@@ -31,9 +31,6 @@ export const useUpdateMyData = () => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (data: UpdateUserRequest) => updateMyData(data),
-    onError: (error) => {
-      console.error("유저 정보 수정 실패:", error);
-    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["users"] });
     },


### PR DESCRIPTION
## :hash: Issue

<!-- 이슈 번호를 작성해 주세요. -->
- close #78 
## :memo: Description

<!-- PR 내용을 불렛 형식으로 자세하게 작성해 주세요. -->
### 로그인 페이지의 토큰 수정 작업 내용입니다. ###
- 사용자가 로그인한 상태에서 세션이 만료되면 토스트 메시지와 로그인 페이지로 리다이렉트
- 리다이렉트 후, 로그인하지 않고 다른 페이지로 이동하면 또 토스트가 뜨는 버그가 있었음
  - sessionStorage를 활용해서 한 번 리다이렉트하면 표시를 남겨 이후에는 토스트나 리다이렉트 안 하도록 차단함
  - 다시 정상적으로 로그인 성공 시에는 sessionStorage 초기화
- 비로그인 상태에서 오늘의 감정 선택 시, 로그인 후 이용해 달라는 토스트 메시지 렌더링
  - 감정도 선택되지 않음
  - 감정 선택 시 발생하는 에러도 토스트 알림 처리
- 불필요한 콘솔 출력 코드 제거
  
## :white_check_mark: Checklist

### PR Checklist

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] Assignee 및 Reviewer, 적절한 Label 지정
- [x] Development 설정

### Additional Notes

<!-- 추가 사항이 있을 경우, 작성해 주세요. -->

- [x] (없음)
