### PR TITLE
fix/81/에피그램페이지

### DIFF
--- a/src/app/(with-header)/(landing)/_components/MainSection.tsx
+++ b/src/app/(with-header)/(landing)/_components/MainSection.tsx
@@ -47,13 +47,14 @@ const SectionContent = ({
         reverse ? "lg:flex-row-reverse" : "lg:flex-row"
       } lg:gap-[80px] lg:items-end items-start lg:w-full lg:max-w-[1200px] lg:px-6 mx-auto`}
     >
-      <motion.div className="shadow-sm rounded-2xl md:hidden" {...motionProps}>
+      <motion.div
+        className="relative w-[312px] h-[210px] shadow-sm rounded-2xl overflow-hidden md:hidden"
+        {...motionProps}
+      >
         <Image
           src={mbImage}
           alt="모바일 섹션 카드"
-          width={312}
-          height={210}
-          className="shadow-sm rounded-2xl"
+          className="absolute object-contain shadow-sm rounded-2xl"
         />
       </motion.div>
       <motion.div
@@ -66,6 +67,7 @@ const SectionContent = ({
           width={384}
           height={240}
           className="shadow-sm rounded-2xl"
+          style={{ width: "auto", height: "auto" }}
         />
       </motion.div>
       <motion.div
@@ -164,6 +166,7 @@ export default function MainSection({ scrollRef }: MainSectionProps) {
             alt="모바일 에피그램 이미지"
             width={312}
             height={576}
+            style={{ width: "auto", height: "auto" }}
           />
         </motion.div>
         <motion.div className="hidden md:block lg:hidden" {...motionProps}>
@@ -172,6 +175,7 @@ export default function MainSection({ scrollRef }: MainSectionProps) {
             alt="태블릿 에피그램 이미지"
             width={384}
             height={688}
+            style={{ width: "auto", height: "auto" }}
           />
         </motion.div>
         <motion.div className="hidden lg:block" {...motionProps}>
@@ -180,6 +184,7 @@ export default function MainSection({ scrollRef }: MainSectionProps) {
             alt="PC 에피그램 이미지"
             width={640}
             height={864}
+            style={{ width: "auto", height: "auto" }}
           />
         </motion.div>
       </div>

--- a/src/app/(with-header)/epigrams/[id]/_components/EpigramDetail.tsx
+++ b/src/app/(with-header)/epigrams/[id]/_components/EpigramDetail.tsx
@@ -114,7 +114,9 @@ export default function EpigramDetail({
                 href={epigramDetail?.referenceUrl}
                 target="_blank"
               >
-                {epigramDetail?.referenceTitle}
+                <span className="max-w-[140px] truncate inline-block align-middle">
+                  {epigramDetail?.referenceTitle}
+                </span>
                 <Image
                   src={externalLink}
                   width={24}

--- a/src/app/(with-header)/login/_components/LoginForm.tsx
+++ b/src/app/(with-header)/login/_components/LoginForm.tsx
@@ -50,7 +50,7 @@ export default function LoginForm() {
     <div className="relative mx-auto max-w-[640px] min-w-[312px] mt-40 mb-40 md:mt-35 md:mb-35 px-4 md:px-0">
       <div className="flex justify-center mb-12">
         <Link href="/">
-          <Image src={logo} alt="로고" width={172} height={48} />
+          <Image src={logo} alt="로고" className="w-[172px] h-[48px]" />
         </Link>
       </div>
       <form onSubmit={handleSubmit(onSubmit)}>

--- a/src/app/(with-header)/signup/_components/SignUpForm.tsx
+++ b/src/app/(with-header)/signup/_components/SignUpForm.tsx
@@ -58,7 +58,7 @@ export default function SignUpForm() {
     <div className="relative mx-auto max-w-[640px] min-w-[312px] mt-14 mb-14 md:mt-20 md:mb-20 px-4 md:px-0">
       <div className="flex justify-center mb-12">
         <Link href="/">
-          <Image src={logo} alt="로고" width={172} height={48} />
+          <Image src={logo} alt="로고" className="w-[172px] h-[48px]" />
         </Link>
       </div>
       <form

--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -31,7 +31,7 @@ export default function Dropdown({ options }: DropdownProps) {
       />
 
       {isOpen && (
-        <ul className="absolute right-0 mt-1 cursor-pointer rounded-2xl border border-blue-300 bg-background-100 drop-shadow-sm z-10 whitespace-nowrap">
+        <ul className="absolute right-0 mt-1 cursor-pointer rounded-2xl border border-blue-300 bg-background-100 drop-shadow-sm z-10 whitespace-nowrap overflow-hidden">
           {options.map((option, index) => (
             <li key={option.label}>
               <button
@@ -39,7 +39,7 @@ export default function Dropdown({ options }: DropdownProps) {
                   option.onClick();
                   setIsOpen(false);
                 }}
-                className={`text-md lg:text-lg cursor-pointer text-center font-medium px-6 lg:px-8 py-2 lg:py-3 text-black-600 hover:bg-blue-200 ${
+                className={`text-md lg:text-lg cursor-pointer text-center font-medium px-6 lg:px-8 py-2 lg:py-3 text-black-600 hover:bg-blue-200 transition ${
                   index === 0 ? "rounded-t-2xl" : ""
                 } ${
                   index === options.length - 1

--- a/src/components/LoggedInHeader.tsx
+++ b/src/components/LoggedInHeader.tsx
@@ -38,6 +38,7 @@ export default function LoggedInHeader({
               src={logo}
               alt="로고"
               className="w-[101px] h-[26px] lg:w-[132px] lg:h-[36px]"
+              priority
             />
           </Link>
           <Link

--- a/src/components/ProfileImage.tsx
+++ b/src/components/ProfileImage.tsx
@@ -49,6 +49,8 @@ export default function ProfileImage({
         src={src || defaultProfile}
         alt="프로필 이미지"
         fill
+        sizes="(max-width: 768px) 64px, (max-width: 1024px) 80x, 96px"
+        priority
       />
     </div>
   );

--- a/src/lib/hooks/useComments.ts
+++ b/src/lib/hooks/useComments.ts
@@ -1,4 +1,9 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  keepPreviousData,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import {
   CommentListResponse,
   CreateCommentRequest,
@@ -29,6 +34,7 @@ export const useCommentList = (params: GetCommentListParams) => {
   return useQuery<CommentListResponse>({
     queryKey: ["comments", params],
     queryFn: () => getCommentList(params),
+    placeholderData: keepPreviousData,
   });
 };
 

--- a/src/lib/hooks/useEpigrams.ts
+++ b/src/lib/hooks/useEpigrams.ts
@@ -1,4 +1,9 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  keepPreviousData,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import {
   GetEpigramListParams,
   EpigramListResponse,
@@ -25,6 +30,7 @@ export const useEpigramList = (params: GetEpigramListParams) => {
   return useQuery<EpigramListResponse>({
     queryKey: ["epigrams", params],
     queryFn: () => getEpigramList(params),
+    placeholderData: keepPreviousData,
   });
 };
 
@@ -85,5 +91,6 @@ export const useEpigramCommentList = (
   return useQuery<EpigramCommentListResponse>({
     queryKey: ["epigrams", id, params],
     queryFn: () => getEpigramCommentList(id!, params),
+    placeholderData: keepPreviousData,
   });
 };

--- a/src/lib/hooks/useUsers.ts
+++ b/src/lib/hooks/useUsers.ts
@@ -1,4 +1,9 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  keepPreviousData,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import {
   CreateProfileImageParams,
   GetUserCommentListParams,
@@ -57,6 +62,7 @@ export const useUserCommentList = (
     queryKey: ["users", id, params],
     queryFn: () => getUserCommentList(id!, params),
     enabled: !!id,
+    placeholderData: keepPreviousData,
   });
 };
 


### PR DESCRIPTION
## :hash: Issue

<!-- 이슈 번호를 작성해 주세요. -->
- close #81 
## :memo: Description

<!-- PR 내용을 불렛 형식으로 자세하게 작성해 주세요. -->
### 에피그램 페이지의 더보기 수정 작업 내용입니다. ###
- 에피그램 페이지 최신 에피그램/댓글 목록, 에피그램 상세 페이지 댓글 목록, 피드 페이지 에피그램 목록, 마이 페이지 내 에피그램/댓글 목록, 검색 페이지 검색 결과 에피그램 목록 더보기 버튼 클릭 시 컴포넌트 새로고침되는 버그 수정
  - 커스텀 훅에 placeholderData 속성을 불러와 keepPreviousData 값을 설정하여 기존에 불러온 데이터가 그대로 유지된 상태에서 추가 데이터를 불러오도록 하였음
- 에피그램 출처 글자가 길 경우 ... 처리
  - truncate : 한 줄 말 줄임(...) 처리
  - max-w-[140px] : 버튼 안에서 최대 너비 제한 
![스크린샷 2025-06-15 093442](https://github.com/user-attachments/assets/4a41004a-4d27-493c-98aa-2ec0fc0a185c)
- Dropdown 아래쪽 그림자 어색했던 부분
  - overflow-hidden 스타일 설정하여 처리함  
- Image 컴포넌트 콘솔 경고 해결
  - 전체 페이지 처리    

## :white_check_mark: Checklist



### PR Checklist

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] Assignee 및 Reviewer, 적절한 Label 지정
- [x] Development 설정

### Additional Notes

<!-- 추가 사항이 있을 경우, 작성해 주세요. -->

- [x] (없음)
